### PR TITLE
chore: add claude to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,4 +25,4 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/kicchann/reqord/blob/main/CLA.md'
           branch: 'main'
-          allowlist: 'kicchann,dependabot[bot],github-actions[bot]'
+          allowlist: 'kicchann,dependabot[bot],github-actions[bot],claude'


### PR DESCRIPTION
## Summary
- Claude Code の Co-Authored-By ヘッダーにより CLA チェックが失敗する問題を修正
- CLA allowlist に `claude` を追加

## Context
PR #4 で CLA Assistant チェックが失敗していた原因の一つ。Claude Code がコミットに `Co-Authored-By: Claude <noreply@anthropic.com>` を付与するため、CLA 署名が必要と判定されていた。

## Test plan
- [x] この PR がマージされた後、PR #4 で `recheck` コメントして CLA チェックを再実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)