### PR TITLE
docs: add technical design documents for all 26 specifications

### DIFF
--- a/.reqord/specifications/spec-000001.json
+++ b/.reqord/specifications/spec-000001.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000001",
+  "requirementId": "req-000001",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:07:39.737Z",
+  "updatedAt": "2026-02-08T14:07:54.055Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000001/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000001/design.md
+++ b/.reqord/specifications/spec-000001/design.md
@@ -1,0 +1,73 @@
+# CLI初期化コマンド - 技術設計書
+
+## 1. 設計概要
+
+`reqord init` コマンドにより `.reqord/` ディレクトリ構造を作成し、要件管理の初期セットアップを行う。ディレクトリ作成、デフォルトテンプレート配置、初期ルールファイル配置を一括で実行する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/init.ts
+                    ↓
+Service Layer:  services/init-service.ts
+                    ↓
+Repository:     repositories/file-system.ts
+                    ↓
+File System:    .reqord/ ディレクトリ構造
+```
+
+単一コマンドで完結する初期化処理のため、レイヤーはシンプルな3層構成。
+
+## 3. コンポーネント設計
+
+### 3.1 initコマンド (`commands/init.ts`)
+
+**責務:** CLIエントリポイント。`process.cwd()` を取得し、サービス層に委譲。
+
+### 3.2 initサービス (`services/init-service.ts`)
+
+**責務:** 初期化ロジックの実行。以下を順次処理:
+
+1. `.reqord/` の存在チェック（既存時はエラー）
+2. ディレクトリ構造の作成:
+   - `context/` + `context/domain/`
+   - `requirements/`
+   - `specifications/`
+   - `settings/templates/` + `settings/rules/`
+   - `assets/`
+3. デフォルトテンプレートの配置:
+   - `settings/templates/requirement-description.md`
+   - `settings/templates/specification-design.md`
+4. デフォルトルールの配置:
+   - `settings/rules/requirement-quality.md`
+
+### 3.3 ファイルシステムリポジトリ (`repositories/file-system.ts`)
+
+**責務:** ファイルI/O抽象化。`mkdirp`, `writeText`, `writeJSON`, `exists` 等を提供。
+
+## 4. データフロー
+
+```
+ユーザー → reqord init
+  → initService.initProject(cwd)
+    → fs.exists(.reqord/) → 既存ならエラー
+    → fs.mkdirp() × 6ディレクトリ
+    → fs.writeText() × テンプレートファイル
+    → fs.writeText() × ルールファイル
+  → 完了サマリー表示
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+- `initProject` がディレクトリ・ファイルを正しく作成すること
+- 既存 `.reqord/` がある場合にエラーを返すこと
+
+### 統合テスト
+- 一時ディレクトリで `reqord init` を実行し、全構造が作成されることを検証
+
+## 6. 技術的決定事項
+
+### テンプレートの埋め込み vs 外部ファイル
+**決定:** `utils/templates.ts` にデフォルトテンプレートをハードコード
+**理由:** npmパッケージ配布時にテンプレートファイルのパス解決が複雑になるため。カスタマイズは `.reqord/settings/templates/` で上書き可能。

--- a/.reqord/specifications/spec-000002.json
+++ b/.reqord/specifications/spec-000002.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000002",
+  "requirementId": "req-000002",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:06.700Z",
+  "updatedAt": "2026-02-08T14:08:06.700Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000002/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000002/design.md
+++ b/.reqord/specifications/spec-000002/design.md
@@ -1,0 +1,132 @@
+# Requirement CRUD - 技術設計書
+
+## 1. 設計概要
+
+要件（Requirement）の作成・一覧・詳細表示・更新・削除の5つのCRUD操作をCLIコマンドとして提供する。各要件はJSON（メタデータ）とMarkdown（説明文）のハイブリッドストレージに保存され、6桁ゼロパディングの自動採番IDで管理される。すべての書き込み操作はZodスキーマによるバリデーションを経由する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/req/create.ts
+                commands/req/list.ts
+                commands/req/show.ts
+                commands/req/update.ts
+                commands/req/delete.ts
+                    ↓
+Service Layer:  services/requirement-service.ts
+                    ↓
+Repository:     repositories/requirement.ts
+                    ↓
+File System:    repositories/file-system.ts
+                    ↓
+Storage:        .reqord/requirements/
+                  ├── req-NNNNNN.json        (メタデータ)
+                  └── req-NNNNNN/
+                      └── description.md     (説明文)
+```
+
+各レイヤーの依存方向は上から下への一方向。Command層はCommander.jsを用いたCLIインターフェースに専念し、ビジネスロジックはService層に委譲する。
+
+## 3. コンポーネント設計
+
+### 3.1 コマンド群 (`commands/req/*.ts`)
+
+**責務:** CLIオプション解析、ユーザー入出力、サービス呼び出し。
+
+| コマンド | 引数・オプション | 出力 |
+|---------|-----------------|------|
+| `create <title>` | `-p, --priority`, `-f, --format` | 作成したID・メタデータ表示 |
+| `list` | `-s, --status`, `-p, --priority`, `--json` | cli-table3によるテーブル表示 |
+| `show <id>` | `--json` | メタデータ全フィールド + description.md表示 |
+| `update <id>` | `-t, --title`, `-s, --status`, `-p, --priority`, `--patch-file`, `--description-file`, `--json` | 変更差分表示 |
+| `delete <id>` | `-f, --force` | 確認プロンプト後削除 |
+
+### 3.2 RequirementService (`services/requirement-service.ts`)
+
+**責務:** CRUD操作のビジネスロジック。
+
+- `createRequirement(cwd, options)`: ID自動採番、デフォルト値設定、テンプレートからdescription.md生成
+- `listRequirements(cwd, options)`: 全件取得 + status/priorityフィルタリング
+- `showRequirement(cwd, id)`: メタデータ + description.md読み込み
+- `updateRequirement(cwd, id, options)`: マージ戦略（patch-file → 個別フラグ上書き）、Zod再検証、updatedAt自動更新
+- `deleteRequirement(cwd, id)`: 存在確認後にJSON + ディレクトリ削除
+
+### 3.3 RequirementRepository (`repositories/requirement.ts`)
+
+**責務:** ファイルI/O。Zodバリデーション付きread、JSON/Markdown write。
+
+- `save(cwd, requirement)`: req-NNNNNN.jsonへJSON書き込み
+- `saveDescription(cwd, id, content)`: req-NNNNNN/description.mdへテキスト書き込み
+- `findById(cwd, id)`: JSON読み込み + RequirementSchema.safeParse
+- `findAll(cwd)`: `req-\d{6}\.json`パターンマッチで全件取得
+- `loadDescription(cwd, id)`: description.mdテキスト読み込み
+- `deleteById(cwd, id)`: JSONファイル + 説明文ディレクトリの再帰削除
+
+### 3.4 ID自動採番 (`utils/id-generator.ts`)
+
+**責務:** 既存ファイル名をスキャンし、最大番号+1で次IDを生成。
+
+- パターン: `req-NNNNNN`（6桁ゼロパディング）
+- 既存ファイルがない場合は `req-000001` から開始
+
+## 4. データフロー
+
+### Create
+
+```
+ユーザー → reqord req create "タイトル" -p high
+  → createCommand.action(title, options)
+    → createRequirement(cwd, { title, priority, format })
+      → generateNextId(cwd) → "req-000001"
+      → Requirementオブジェクト構築（デフォルト値含む）
+      → reqRepo.save(cwd, requirement) → req-000001.json書き込み
+      → loadProjectTemplate() → テンプレート取得（or デフォルト）
+      → reqRepo.saveDescription(cwd, id, description) → description.md書き込み
+  → 成功メッセージ + メタデータ表示
+```
+
+### Update
+
+```
+ユーザー → reqord req update req-000001 --status approved --patch-file patch.json
+  → updateCommand.action(id, options)
+    → updateRequirement(cwd, id, { status, patchData })
+      → reqRepo.findById(cwd, id) → before取得
+      → マージ: existing ← patchData ← 個別フラグ
+      → updatedAt更新、immutableフィールド保持（id, createdAt, files）
+      → RequirementSchema.safeParse(merged) → バリデーション
+      → reqRepo.save(cwd, after)
+      → descriptionContent指定時: reqRepo.saveDescription()
+  → 変更差分表示（before vs after）
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **requirement-service**: 各CRUD関数の正常系・異常系テスト。リポジトリをモック化し、ビジネスロジック（マージ戦略、フィルタリング、存在確認）を検証
+- **id-generator**: 既存ファイルなし→req-000001、既存ファイルあり→最大番号+1
+- **repositories/requirement.ts**: Zodバリデーション失敗時のエラー、ファイル不在時のnull返却
+
+### 統合テスト
+
+- 一時ディレクトリで create → list → show → update → delete の一連フローを実行
+- フィルタリング（--status, --priority）の動作検証
+- --patch-file, --description-fileによるバルク更新の検証
+
+## 6. 技術的決定事項
+
+### JSON + Markdownハイブリッドストレージ
+
+**決定:** メタデータはJSON、説明文はMarkdownとして分離保存
+**理由:** メタデータの構造化検索・バリデーションにはJSONが適切。説明文はMarkdownエディタやGitで自然に扱えるフォーマット。人間の編集容易性とプログラム的な構造化の両立。
+
+### 更新時のマージ戦略
+
+**決定:** `patch-file → 個別フラグ上書き`の優先順位。immutableフィールド（id, createdAt, files）は常に元の値を保持
+**理由:** patch-fileはAIエージェントからの一括更新用途、個別フラグは人間の明示的指定。明示的指定が優先されるのが直感的。
+
+### 削除時の確認プロンプト
+
+**決定:** デフォルトで確認プロンプト表示、`--force`でスキップ可能
+**理由:** 破壊的操作の安全性確保。AIエージェントからの利用時は`--force`で非対話的に実行可能。

--- a/.reqord/specifications/spec-000003.json
+++ b/.reqord/specifications/spec-000003.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000003",
+  "requirementId": "req-000003",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:06.788Z",
+  "updatedAt": "2026-02-08T14:08:06.788Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000003/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000003/design.md
+++ b/.reqord/specifications/spec-000003/design.md
@@ -1,0 +1,143 @@
+# ProjectContext CRUD - 技術設計書
+
+## 1. 設計概要
+
+プロジェクトコンテキスト（プロダクト情報、技術スタック、プロジェクト構造、ドメイン知識）の初期化・表示・更新を提供する。コンテキストは複数のJSONファイルに分散保存され、`context.json`がルートメタデータ、`product.json`/`technical.json`/`structure.json`が個別の詳細情報、`domain/`ディレクトリがドメイン知識ファイルを格納する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/context/init.ts
+                commands/context/show.ts
+                commands/context/update.ts
+                    ↓
+Service Layer:  services/context-service.ts
+                    ↓
+Repository:     repositories/project-context.ts
+                    ↓
+File System:    repositories/file-system.ts
+                    ↓
+Storage:        .reqord/context/
+                  ├── context.json       (ルートメタデータ)
+                  ├── product.json       (プロダクト情報)
+                  ├── technical.json     (技術スタック)
+                  ├── structure.json     (プロジェクト構造)
+                  └── domain/            (ドメイン知識)
+```
+
+RequirementのCRUDと同じCommand → Service → Repository → FileSystemパターンに従う。
+
+## 3. コンポーネント設計
+
+### 3.1 コマンド群 (`commands/context/*.ts`)
+
+| コマンド | 引数・オプション | 出力 |
+|---------|-----------------|------|
+| `context init <name>` | `-l, --language <lang>` (デフォルト: ja) | メタデータ表示 + 生成ファイル一覧 |
+| `context show` | `--json`, `--detail` | サマリー表示 / JSON出力 / ファイル内容表示 |
+| `context update` | `-n, --name`, `-v, --version`, `--product <path>`, `--technical <path>`, `--structure <path>`, `--json` | 変更差分表示 |
+
+### 3.2 ContextService (`services/context-service.ts`)
+
+**責務:** コンテキスト管理のビジネスロジック。
+
+- `initContext(cwd, options)`: 既存チェック → context.json生成 → テンプレートファイル（product/technical/structure）配置 → domain/ディレクトリ作成
+- `showContext(cwd)`: context.json読み込み + 各ファイルの存在確認 + domain/配下のファイル一覧取得 + 各ファイルの内容読み込み
+- `updateContext(cwd, options)`: context.jsonのメタデータ更新 + 各サブファイルのパッチ適用（シャローマージ）
+
+**ヘルパー:**
+- `resolveFilePath(fileRef)`: files構造のファイル参照（文字列/オブジェクト）をパスに解決
+
+### 3.3 ProjectContextRepository (`repositories/project-context.ts`)
+
+**責務:** コンテキスト関連ファイルのI/O。
+
+- `load(cwd)`: context.json読み込み + ProjectContextSchema.safeParse
+- `save(cwd, context)`: context.json書き込み
+- `contextExists(cwd)`: context.jsonの存在確認
+- `loadContextFile(cwd, fileType)`: product/technical/structureの個別読み込み
+- `saveContextFile(cwd, fileType, data)`: 個別ファイル書き込み
+
+### 3.4 ProjectContextSchema (`@reqord/shared`)
+
+```typescript
+{
+  id: string,
+  name: string,
+  version: string,       // デフォルト "0.1.0"
+  language: string,      // デフォルト "ja"
+  createdAt?: string,
+  updatedAt?: string,
+  files: {
+    product: string | { path: string, format: string },
+    technical: string | { structured: string, narrative?: string },
+    structure: string | { structured: string, narrative?: string },
+    domain: string[],
+  }
+}
+```
+
+## 4. データフロー
+
+### Init
+
+```
+ユーザー → reqord context init "MyProject"
+  → contextInitCommand.action(name, options)
+    → initContext(cwd, { id, name, language })
+      → contextRepo.contextExists(cwd) → false確認
+      → ProjectContextオブジェクト構築
+      → contextRepo.save(cwd, context)
+      → テンプレートファイル生成:
+        - product.json: { name, vision, goals, targetUsers }
+        - technical.json: { stack, constraints, decisions }
+        - structure.json: { modules, layers }
+      → domain/ディレクトリ作成
+  → メタデータ + 生成ファイル一覧表示
+```
+
+### Update（パッチファイル使用）
+
+```
+ユーザー → reqord context update --technical tech-patch.json
+  → contextUpdateCommand.action(options)
+    → loadPatchFile("tech-patch.json") → JSONオブジェクト
+    → updateContext(cwd, { technicalPatch })
+      → contextRepo.load(cwd) → before
+      → context.jsonのupdatedAt更新 → contextRepo.save()
+      → contextRepo.loadContextFile(cwd, "technical") → existing
+      → シャローマージ: { ...existing, ...patch }
+      → contextRepo.saveContextFile(cwd, "technical", merged)
+  → 変更サマリー表示
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **context-service**: init/show/updateの各関数。リポジトリモック化。既存context.jsonがある場合のinit拒否、ファイル不在時のshow動作
+- **project-context repository**: Zodバリデーション、ファイル読み書き
+- **resolveFilePath**: 文字列/オブジェクト形式両方のファイル参照解決
+
+### 統合テスト
+
+- 一時ディレクトリで init → show → update の一連フローを実行
+- --detail オプションでファイル内容が正しく表示されることを検証
+- パッチファイルによる更新がシャローマージされることを検証
+
+## 6. 技術的決定事項
+
+### ファイル分散構造
+
+**決定:** context.json + product.json + technical.json + structure.json + domain/ に分離
+**理由:** 一つのファイルにすべてを格納すると巨大化し、部分更新が困難になる。各領域を独立ファイルにすることで、AIエージェントやユーザーが特定領域のみを更新できる。
+
+### filesフィールドの柔軟な参照形式
+
+**決定:** `string | { path, format }` や `{ structured, narrative? }` のユニオン型
+**理由:** 初期は単純なパス文字列で開始し、将来的にnarrativeドキュメント（自然言語による説明）やフォーマット指定を追加可能にする拡張性の確保。
+
+### パッチファイルによる更新
+
+**決定:** JSON patchファイルをシャローマージで適用
+**理由:** AIエージェントが技術スタック情報などを一括で設定・更新する際に、個別CLIオプションでは表現しきれない複雑な構造を扱える。

--- a/.reqord/specifications/spec-000004.json
+++ b/.reqord/specifications/spec-000004.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000004",
+  "requirementId": "req-000004",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:06.872Z",
+  "updatedAt": "2026-02-08T14:08:06.872Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000004/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000004/design.md
+++ b/.reqord/specifications/spec-000004/design.md
@@ -1,0 +1,156 @@
+# 共有型定義 (@reqord/shared) - 技術設計書
+
+## 1. 設計概要
+
+モノレポ内のpackages/cli と packages/web が共有するZodスキーマ、TypeScript型、定数、バリデーションロジックを `@reqord/shared` パッケージとして提供する。Zodによるランタイムバリデーションと静的型推論の統合により、単一定義から型安全性と実行時検証の両方を実現する。
+
+## 2. アーキテクチャ
+
+```
+@reqord/shared (packages/shared/)
+  ├── src/
+  │   ├── index.ts                      (re-export)
+  │   ├── schemas/
+  │   │   ├── index.ts                  (schemas re-export)
+  │   │   ├── common.ts                 (共通型: Status, Priority, Complexity)
+  │   │   ├── requirement.ts            (RequirementSchema)
+  │   │   ├── project-context.ts        (ProjectContextSchema)
+  │   │   ├── specification.ts          (SpecificationSchema)
+  │   │   └── validation.ts             (ValidationResultSchema)
+  │   ├── constants/
+  │   │   ├── index.ts                  (constants re-export)
+  │   │   └── paths.ts                  (ディレクトリパス定数)
+  │   └── validation/
+  │       ├── smart-scoring.ts          (SMARTスコア算出)
+  │       └── ambiguous-phrases.ts      (曖昧表現リスト)
+  └── dist/                            (tscビルド出力)
+
+依存関係:
+  packages/cli  ──workspace:*──→ @reqord/shared
+  packages/web  ──workspace:*──→ @reqord/shared
+```
+
+### パッケージ間の依存方向
+
+```
+packages/cli   → @reqord/shared ← packages/web
+     ↓                                ↓
+ ファイルシステム              ファイルシステム（Server Actions経由）
+```
+
+cli と web は shared に依存するが、shared は他パッケージに依存しない。外部依存は zod のみ。
+
+## 3. コンポーネント設計
+
+### 3.1 共通スキーマ (`schemas/common.ts`)
+
+**責務:** 複数スキーマから参照される基本型定義。
+
+| スキーマ | 値 | 用途 |
+|---------|-----|------|
+| `StatusSchema` | `"draft" \| "pending_approval" \| "approved" \| "deprecated"` | 要件・仕様の状態管理 |
+| `PrioritySchema` | `"low" \| "medium" \| "high"` | 要件の優先度 |
+| `ComplexitySchema` | `"small" \| "medium" \| "large" \| "xlarge"` | 実装複雑度 |
+| `FormatTypeSchema` | `"user-story" \| "ears" \| "free-form"` | 要件記述形式 |
+| `VersionHistoryEntrySchema` | `{ version, status, gitCommit, approvedAt, approvedBy }` | バージョン履歴エントリ |
+
+### 3.2 RequirementSchema (`schemas/requirement.ts`)
+
+**責務:** 要件データの完全なスキーマ定義。
+
+- ID: `req-\d{6}`パターン（正規表現バリデーション）
+- FormatSchema: discriminatedUnion（type フィールドでuser-story/ears/free-formを判別）
+- DependenciesSchema: blockedBy/blocks/relatedToの3方向依存関係
+- オプションフィールド: estimatedComplexity, estimatedHours
+
+### 3.3 ProjectContextSchema (`schemas/project-context.ts`)
+
+**責務:** プロジェクトコンテキストのスキーマ定義。
+
+- filesフィールド: string | object のユニオン型で柔軟なファイル参照をサポート
+
+### 3.4 SpecificationSchema (`schemas/specification.ts`)
+
+**責務:** 仕様書データのスキーマ定義。
+
+- requirementIdで要件との紐付け
+- filesにdesignドキュメントパスを保持
+
+### 3.5 ValidationResultSchema (`schemas/validation.ts`)
+
+**責務:** バリデーション結果の構造化データ定義。
+
+- `ValidationIssueSchema`: type, severity（error/warning/info）, field, message, suggestion
+- `SmartScoreSchema`: SMART基準の各軸スコア（0-1）+ overall
+- `ValidationMetadataSchema`: criteriaCount, hasDescription, hasDependencyIssues, validatedAt
+
+### 3.6 パス定数 (`constants/paths.ts`)
+
+**責務:** .reqord/配下のディレクトリ名を定数化。
+
+- `REQORD_DIR`, `CONTEXT_DIR`, `REQUIREMENTS_DIR`, `SPECIFICATIONS_DIR`, `SETTINGS_DIR`, `TEMPLATES_DIR`, `RULES_DIR`, `ASSETS_DIR`, `DOMAIN_DIR`, `ISSUE_TEMPLATES_DIR`
+
+### 3.7 SMARTスコアリング (`validation/smart-scoring.ts`)
+
+**責務:** ルールベース（AI不要）でのSMART基準スコア算出。
+
+- Specific: タイトル長 + description有無・長さ + format詳細充実度 + 曖昧表現の少なさ
+- Measurable: 成功基準の数・具体性・数値基準の有無
+- Achievable: 複雑度設定 + 見積もり時間設定 + 整合性
+- Relevant: formatの充実度 + 依存関係の定義
+- TimeBound: 見積もり時間 + 複雑度 + 時間制約表現
+
+### 3.8 曖昧表現検出 (`validation/ambiguous-phrases.ts`)
+
+**責務:** 日本語の曖昧表現リスト提供。
+
+- 「適切に」「なるべく」「できるだけ」等の42表現
+- `getAmbiguousPhrases(language)`: 言語コードに応じたリスト返却（現時点はjaのみ）
+
+## 4. データフロー
+
+```
+CLI/Web → import { RequirementSchema, type Requirement } from "@reqord/shared"
+  → Zodスキーマでランタイムバリデーション:
+    RequirementSchema.safeParse(rawData) → { success, data, error }
+  → 型推論: z.infer<typeof RequirementSchema> → Requirement型
+
+CLI/Web → import { calculateSmartScore } from "@reqord/shared"
+  → calculateSmartScore({ requirement, description, language })
+  → SmartScore { specific, measurable, achievable, relevant, timeBound, overall }
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **smart-scoring.ts**: 各SMART軸のスコア算出。空の要件→低スコア、充実した要件→高スコア
+- **ambiguous-phrases.ts**: 曖昧表現カウント、言語切り替え
+- **isComplexityHoursConsistent**: 複雑度と見積もり時間の整合性判定
+
+### スキーマテスト
+
+- RequirementSchema: 正常データのparse成功、不正ID/不正status等のparse失敗
+- ProjectContextSchema: filesの各ユニオン型パターンのparse
+
+## 6. 技術的決定事項
+
+### Zodによるスキーマ定義
+
+**決定:** TypeScript型定義ではなくZodスキーマを正とし、`z.infer`で型を導出
+**理由:** JSONファイルの読み込み時にランタイムバリデーションが必須。Zodならスキーマ定義と型定義を一箇所に統合でき、型定義の乖離を防止できる。
+
+### tsc composite: trueでのビルド
+
+**決定:** TypeScript Project References（composite: true）を使用
+**理由:** cli パッケージが shared を参照する際にインクリメンタルビルドが可能。ただし `--noEmit` と `composite` の競合を避けるため、型チェックには別途 `tsconfig.check.json` を使用。
+
+### workspace:* プロトコル
+
+**決定:** pnpm の `workspace:*` でモノレポ内パッケージ間依存を管理
+**理由:** npm publish時に自動的にバージョン番号に変換される。開発時は常に最新のローカルビルドが使用される。
+
+### 外部依存の最小化
+
+**決定:** shared パッケージの外部依存は zod のみ
+**理由:** cli や web から広く参照されるパッケージのため、依存ツリーを最小限に保つことが重要。バリデーションロジックはルールベースで実装し、AI SDKなどの重い依存は含めない。

--- a/.reqord/specifications/spec-000005.json
+++ b/.reqord/specifications/spec-000005.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000005",
+  "requirementId": "req-000005",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:06.961Z",
+  "updatedAt": "2026-02-08T14:08:06.961Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000005/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000005/design.md
+++ b/.reqord/specifications/spec-000005/design.md
@@ -1,0 +1,149 @@
+# Requirementバージョン管理 - 技術設計書
+
+## 1. 設計概要
+
+要件のライフサイクル管理として、セマンティックバージョニング（major/minor/patch）による変更追跡と状態遷移（draft → pending_approval → approved → deprecated）を実装する。要件更新時にversionHistoryへ自動的に履歴エントリを追加し、`reqord req history <id>` コマンドで変更履歴を表示する。本機能は未実装であり、既存のRequirementスキーマに定義済みの `version` / `versionHistory` フィールドを活用する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/req/history.ts  (新規)
+                commands/req/update.ts   (既存拡張)
+                    ↓
+Service Layer:  services/requirement-service.ts (既存拡張)
+                services/version-service.ts     (新規)
+                    ↓
+Repository:     repositories/requirement.ts     (既存)
+                    ↓
+Shared:         @reqord/shared
+                  schemas/common.ts             (VersionHistoryEntrySchema既存)
+                  schemas/requirement.ts        (version, versionHistory既存)
+```
+
+既存のスキーマ定義（VersionHistoryEntrySchema）とフィールド（versionHistory配列）はすでに存在するため、新規コードは主にサービス層のバージョン管理ロジックとhistoryコマンドの追加となる。
+
+## 3. コンポーネント設計
+
+### 3.1 historyコマンド (`commands/req/history.ts` - 新規)
+
+**責務:** 指定要件のバージョン履歴を表示。
+
+```
+reqord req history <id> [--json]
+```
+
+- テーブル形式: version, status, gitCommit(短縮), approvedAt, approvedBy
+- `--json`: ValidationResult同様のJSON出力
+
+### 3.2 VersionService (`services/version-service.ts` - 新規)
+
+**責務:** バージョン管理ロジックの提供。
+
+- `determineNextVersion(before, after)`: 変更内容に基づくバージョン番号決定
+  - **major**: status変更（draft → approved等の状態遷移）
+  - **minor**: title, format, dependencies, successCriteria等の構造変更
+  - **patch**: description.mdのみの変更、priority変更
+- `createHistoryEntry(requirement, gitCommit?)`: VersionHistoryEntryの生成
+- `getStateTransitions()`: 許可される状態遷移マップの提供
+
+### 3.3 RequirementService 拡張
+
+**変更点:** updateRequirement内でのバージョン自動インクリメント。
+
+```typescript
+// draft状態ではバージョンインクリメントしない
+if (before.status !== "draft" || after.status !== "draft") {
+  const nextVersion = determineNextVersion(before, after);
+  after.version = nextVersion;
+  after.versionHistory.push(createHistoryEntry(after, gitCommit));
+}
+```
+
+### 3.4 状態遷移ルール
+
+```
+draft ──→ pending_approval ──→ approved ──→ deprecated
+  ↑            │
+  └────────────┘ (差し戻し)
+```
+
+許可される遷移:
+- `draft` → `pending_approval`
+- `pending_approval` → `approved`
+- `pending_approval` → `draft`（差し戻し）
+- `approved` → `deprecated`
+
+禁止される遷移:
+- `approved` → `draft`（承認済みを直接ドラフトに戻すことは不可）
+- `deprecated` → いずれの状態にも戻せない
+
+### 3.5 VersionHistoryEntry（既存スキーマ）
+
+```typescript
+{
+  version: string,      // "1.2.3"
+  status: Status,       // 記録時点の状態
+  gitCommit: string,    // Gitコミットハッシュ（空文字列許容）
+  approvedAt: string,   // ISO 8601タイムスタンプ
+  approvedBy: string[], // 承認者リスト
+}
+```
+
+## 4. データフロー
+
+### 更新時の自動バージョニング
+
+```
+ユーザー → reqord req update req-000001 --status approved
+  → updateRequirement(cwd, id, { status: "approved" })
+    → before取得（status: "pending_approval", version: "1.0.0"）
+    → 状態遷移チェック: pending_approval → approved（許可）
+    → determineNextVersion(before, after) → "2.0.0"（status変更=major）
+    → createHistoryEntry(after, gitCommit)
+    → versionHistory.push(entry)
+    → reqRepo.save(cwd, after)
+```
+
+### 履歴表示
+
+```
+ユーザー → reqord req history req-000001
+  → showRequirement(cwd, id)
+    → requirement.versionHistory取得
+  → テーブル表示:
+    | Version | Status           | Commit  | Date       |
+    | 1.0.0   | draft            | abc1234 | 2025-01-01 |
+    | 1.1.0   | pending_approval | def5678 | 2025-01-05 |
+    | 2.0.0   | approved         | ghi9012 | 2025-01-10 |
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **version-service**: バージョン番号決定ロジック（major/minor/patch各ケース）
+- **状態遷移**: 許可/禁止される遷移パターンの網羅テスト
+- **createHistoryEntry**: エントリ生成の各フィールド検証
+- **draft状態での更新**: バージョンインクリメントされないことの確認
+
+### 統合テスト
+
+- create → update(title変更) → update(status変更) → history表示の一連フロー
+- 不正な状態遷移（approved → draft）のエラーハンドリング
+
+## 6. 技術的決定事項
+
+### セマンティックバージョニングの粒度
+
+**決定:** major=状態遷移、minor=構造変更、patch=軽微な変更
+**理由:** npmのsemverとは異なるが、要件管理の文脈では「状態が変わった」が最も重要な変更。構造的な内容変更はminor、文書的な修正はpatchとすることで、変更の重要度が直感的に分かる。
+
+### draft状態でのバージョンスキップ
+
+**決定:** draft状態での更新ではバージョンをインクリメントしない
+**理由:** draft段階は試行錯誤のフェーズであり、すべての編集を履歴に残すとノイズが大きい。pending_approval以降の変更のみを正式な履歴として記録する。
+
+### Gitコミットハッシュの取得
+
+**決定:** 環境変数またはgitコマンド実行で現在のHEADコミットを取得。取得失敗時は空文字列
+**理由:** Git管理下でない環境でも動作する必要がある。コミットハッシュは参考情報であり、必須ではない。

--- a/.reqord/specifications/spec-000006.json
+++ b/.reqord/specifications/spec-000006.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000006",
+  "requirementId": "req-000006",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.042Z",
+  "updatedAt": "2026-02-08T14:08:07.042Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000006/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000006/design.md
+++ b/.reqord/specifications/spec-000006/design.md
@@ -1,0 +1,164 @@
+# AIエージェント向けCLI最適化 - 技術設計書
+
+## 1. 設計概要
+
+reqord CLIをAIエージェント（Claude Code等）がツールとして利用しやすくするための最適化を行う。構造化出力（`--json`）、一括入力（`--patch-file`, `--description-file`）、品質バリデーション（`reqord req validate`）、およびClaude Codeスラッシュコマンド（`.claude/commands/reqord/refine.md`）を提供する。reqord自体にはAI SDKを含めず、外部エージェントがCLIをプロセスとして呼び出す設計とする。
+
+## 2. アーキテクチャ
+
+```
+AI Agent (Claude Code等)
+    ↓ subprocess呼び出し
+reqord CLI
+    ├── --json 出力       → stdout: JSON
+    ├── --patch-file 入力 → ファイル経由の一括更新
+    ├── --description-file → Markdown更新
+    ├── req validate      → 品質チェック結果
+    └── exit code         → 0: 成功 / 1: エラー
+
+Claude Code統合:
+    .claude/commands/reqord/refine.md
+        → reqord req show → validate → update のサイクル
+
+バリデーションスタック:
+    commands/req/validate.ts
+        ↓
+    services/validation-service.ts
+        ↓
+    @reqord/shared
+        ├── validation/smart-scoring.ts
+        └── validation/ambiguous-phrases.ts
+```
+
+エージェントとreqordの間のインターフェースはCLIのstdin/stdout/stderr + exit codeのみ。バイナリプロトコルやAPIサーバーは持たない。
+
+## 3. コンポーネント設計
+
+### 3.1 --json 出力オプション（既存・部分実装済み）
+
+**対象コマンド:** list, show, update, context show, context update, validate
+
+**責務:** 構造化データのstdout出力。
+
+- 人間向け出力をスキップし、`JSON.stringify(data, null, 2)` をstdoutに出力
+- エラー時はstderrにメッセージ出力 + exit code 1
+- エージェントは `JSON.parse(stdout)` でパース可能
+
+### 3.2 --patch-file オプション（実装済み）
+
+**責務:** JSONファイルによる一括更新。
+
+```bash
+# AIエージェントが一時ファイルを生成してCLI呼び出し
+reqord req update req-000001 --patch-file /tmp/patch.json
+```
+
+- 許可フィールド: title, status, priority, successCriteria, format, dependencies, estimatedComplexity, estimatedHours
+- immutableフィールド（id, createdAt, files）は上書き不可
+- 個別フラグ（--title等）が--patch-fileより優先
+
+### 3.3 --description-file オプション（実装済み）
+
+**責務:** Markdownファイルによるdescription.md更新。
+
+```bash
+reqord req update req-000001 --description-file /tmp/desc.md
+```
+
+### 3.4 validateコマンド (`commands/req/validate.ts` - 実装済み)
+
+**責務:** 要件の品質チェックと構造化結果出力。
+
+| チェック項目 | 種別 | 説明 |
+|-------------|------|------|
+| 曖昧表現検出 | warning | 日本語42表現のマッチング |
+| 成功基準チェック | error/warning | 0件→error、1-2件→warning、8件以上→warning |
+| 依存関係整合性 | error | 存在しないIDへの参照 |
+| 循環依存検出 | error | DFSによる循環検出 |
+| 複雑度・時間整合性 | warning | small(1-8h), medium(4-40h)等の範囲チェック |
+| SMARTスコア | info | Specific/Measurable/Achievable/Relevant/TimeBound |
+
+**出力形式:**
+- 人間向け: 色付きバー表示 + issue一覧
+- `--json`: ValidationResult構造体（id, valid, issues[], smartScore, metadata）
+
+### 3.5 Claude Codeスラッシュコマンド (`.claude/commands/reqord/refine.md`)
+
+**責務:** Claude Codeからの要件改善ワークフローガイド。
+
+- `reqord req show <id> --json` で現状取得
+- `reqord req validate <id> --json` で品質チェック
+- issueに基づき改善案を生成
+- `reqord req update <id> --patch-file` で更新適用
+
+## 4. データフロー
+
+### エージェントによる要件改善フロー
+
+```
+Claude Code
+  → reqord req show req-000001 --json
+    → stdout: { id, title, status, ... , description }
+  → reqord req validate req-000001 --json
+    → stdout: { valid: false, issues: [...], smartScore: {...} }
+  → 改善案生成（エージェント内部処理）
+  → /tmp/patch.json 生成
+  → reqord req update req-000001 --patch-file /tmp/patch.json --description-file /tmp/desc.md
+    → stdout: { ...updatedRequirement }
+  → reqord req validate req-000001 --json
+    → stdout: { valid: true, smartScore: { overall: 0.85 } }
+```
+
+### バリデーション内部フロー
+
+```
+validateCommand.action(id)
+  → validateRequirement(cwd, id)
+    → reqRepo.findById(cwd, id) → requirement
+    → reqRepo.loadDescription(cwd, id) → description
+    → reqRepo.findAll(cwd) → allRequirements（依存関係チェック用）
+    → checkAmbiguousPhrases(requirement, description, language, issues)
+    → checkSuccessCriteria(requirement, issues)
+    → checkDependencies(requirement, allRequirements, issues)
+    → checkCircularDependencies(requirement, allRequirements, issues)
+    → checkComplexityHoursConsistency(requirement, issues)
+    → calculateSmartScore({ requirement, description, language })
+  → ValidationResult構築 → 出力
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **validation-service**: 各チェック関数の個別テスト（曖昧表現、成功基準、依存関係、循環依存、複雑度整合性）
+- **smart-scoring**: SMARTスコア算出の境界値テスト（0%/50%/100%スコア）
+- **--json出力**: JSON.parseが成功すること、必要なフィールドが含まれること
+
+### 統合テスト
+
+- 要件作成 → validate → 不合格 → 改善 → validate → 合格 の一連フロー
+- 循環依存の検出（A→B→C→Aパターン）
+- --patch-file + --description-file の同時指定
+
+### エージェント互換性テスト
+
+- exit code: valid=true→0、valid=false→1
+- stdoutがJSON.parseableであること
+- stderrにのみエラーメッセージが出力されること
+
+## 6. 技術的決定事項
+
+### AI SDKを含めない設計
+
+**決定:** reqord自体にはAI SDKを含めず、CLIインターフェースのみ提供
+**理由:** AI SDKのバージョン管理やAPI Key管理の複雑さを回避。エージェントごとに異なるLLMを使用可能。reqordは「ツール」として純粋な要件管理機能のみに集中する。
+
+### CLIプロセス呼び出しによる統合
+
+**決定:** エージェントはreqordをサブプロセスとして呼び出す
+**理由:** 言語・フレームワーク非依存。stdin/stdout/stderrという普遍的なインターフェースにより、どのAIエージェントからも利用可能。HTTPサーバー等の起動が不要。
+
+### スコアリングのルールベース実装
+
+**決定:** SMARTスコアリングをAIではなくルールベースで実装
+**理由:** オフライン動作、決定論的な結果、API制限なし。AIによる高度な評価は外部エージェント側の責務とする。

--- a/.reqord/specifications/spec-000007.json
+++ b/.reqord/specifications/spec-000007.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000007",
+  "requirementId": "req-000007",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.128Z",
+  "updatedAt": "2026-02-08T14:08:07.128Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000007/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000007/design.md
+++ b/.reqord/specifications/spec-000007/design.md
@@ -1,0 +1,228 @@
+# ローカルUI - 要件管理画面 - 技術設計書
+
+## 1. 設計概要
+
+Next.js 15 App Routerを用いたローカルWebUIで、要件の一覧表示・詳細表示・新規作成・編集画面を提供する。CLIと同じ `.reqord/` ディレクトリ内のファイルシステムに直接アクセスし、Server Actionsを通じてCRUD操作を行う。依存関係グラフの可視化は本仕様のスコープ外（spec-000023で扱う）。
+
+## 2. アーキテクチャ
+
+```
+packages/web/src/
+  ├── app/                               (App Router ページ)
+  │   ├── layout.tsx                     (共通レイアウト)
+  │   ├── page.tsx                       (ルートページ)
+  │   ├── error.tsx                      (エラーバウンダリ)
+  │   ├── requirements/
+  │   │   ├── page.tsx                   (一覧ページ)
+  │   │   ├── loading.tsx                (一覧ローディング)
+  │   │   ├── new/page.tsx               (新規作成ページ)
+  │   │   └── [id]/
+  │   │       ├── page.tsx               (詳細ページ)
+  │   │       ├── loading.tsx            (詳細ローディング)
+  │   │       ├── not-found.tsx          (404ページ)
+  │   │       └── edit/page.tsx          (編集ページ)
+  │   └── graph/page.tsx                 (グラフページ - spec-000023)
+  ├── components/
+  │   ├── requirement/                   (要件コンポーネント群)
+  │   │   ├── requirement-table.tsx      (一覧テーブル)
+  │   │   ├── requirement-detail.tsx     (詳細表示)
+  │   │   ├── requirement-form.tsx       (作成・編集フォーム)
+  │   │   ├── markdown-editor.tsx        (Markdownエディタ)
+  │   │   ├── markdown-renderer.tsx      (Markdownレンダラ)
+  │   │   ├── success-criteria-editor.tsx (成功基準エディタ)
+  │   │   ├── dependency-editor.tsx      (依存関係エディタ)
+  │   │   └── delete-button.tsx          (削除ボタン)
+  │   └── ui/
+  │       ├── badge.tsx                  (ステータスバッジ)
+  │       └── nav.tsx                    (ナビゲーション)
+  └── lib/
+      ├── repository.ts                  (RequirementRepositoryインターフェース)
+      ├── local-repository.ts            (ファイルシステム実装)
+      ├── get-repository.ts              (リポジトリファクトリ)
+      ├── data.ts                        (データ取得関数)
+      ├── actions.ts                     (Server Actions)
+      ├── file-system.ts                 (ファイルI/Oユーティリティ)
+      ├── id-generator.ts                (ID自動採番)
+      └── reqord-root.ts                 (REQORD_ROOT環境変数解決)
+```
+
+### データアクセスの流れ
+
+```
+ブラウザ → Next.js Server Component / Server Action
+              ↓
+         lib/data.ts (読み取り) / lib/actions.ts (書き込み)
+              ↓
+         lib/get-repository.ts → LocalRequirementRepository
+              ↓
+         lib/file-system.ts
+              ↓
+         .reqord/requirements/ (ファイルシステム)
+```
+
+## 3. コンポーネント設計
+
+### 3.1 ページコンポーネント
+
+#### 一覧ページ (`requirements/page.tsx`)
+
+- Server Componentとして全要件を取得
+- `<RequirementTable>` にデータを渡す
+- `<Suspense>` + `<Loading>` でストリーミング表示
+- 「New Requirement」リンクボタン
+- `dynamic = "force-dynamic"` でキャッシュ無効化
+
+#### 詳細ページ (`requirements/[id]/page.tsx`)
+
+- `generateMetadata` で動的タイトル生成
+- `Promise.all([getRequirementById, getRequirementDescription])` で並列取得
+- 要件不在時は `notFound()` で404ページ表示
+- `<RequirementDetail>` コンポーネントに委譲
+
+#### 新規作成ページ (`requirements/new/page.tsx`)
+
+- `<RequirementForm mode="create">` を表示
+- 全要件リスト取得（依存関係選択用）
+
+#### 編集ページ (`requirements/[id]/edit/page.tsx`)
+
+- 対象要件 + description + 全要件リスト（依存関係選択用）を取得
+- `<RequirementForm mode="edit">` に既存データを渡す
+
+### 3.2 UIコンポーネント
+
+#### RequirementTable
+
+- 一覧テーブル表示（ID, Title, Status, Priority）
+- 各行クリックで詳細ページへ遷移
+- ステータス・優先度のカラーバッジ表示
+
+#### RequirementForm
+
+- `mode: "create" | "edit"` で新規作成/編集を切り替え
+- フォーマット選択: user-story / ears / free-form（選択に応じた動的フォーム）
+- MarkdownEditor: description.mdの編集
+- SuccessCriteriaEditor: 成功基準の動的リスト追加・削除
+- DependencyEditor: blockedBy/blocks/relatedToの選択
+- Server Action (`createRequirement` / `updateRequirement`) でフォーム送信
+
+#### RequirementDetail
+
+- 全フィールドの読み取り表示
+- description.mdのMarkdownレンダリング
+- Edit/Deleteボタン
+
+#### DeleteButton
+
+- 削除確認付きボタン
+- Server Action (`deleteRequirement`) 呼び出し後にリダイレクト
+
+### 3.3 データ層
+
+#### RequirementRepository インターフェース
+
+```typescript
+interface RequirementRepository {
+  findAll(): Promise<Requirement[]>;
+  findById(id: string): Promise<Requirement | null>;
+  loadDescription(id: string): Promise<string | null>;
+  save(requirement: Requirement): Promise<void>;
+  saveDescription(id: string, content: string): Promise<void>;
+  deleteById(id: string): Promise<void>;
+  generateNextId(): Promise<string>;
+}
+```
+
+#### LocalRequirementRepository
+
+- CLI版repositoryと同等のファイルI/Oロジック
+- `REQORD_ROOT` 環境変数で `.reqord/` ディレクトリを特定
+- `@reqord/shared` のRequirementSchema.safeParseでバリデーション
+
+#### Server Actions (`lib/actions.ts`)
+
+- `createRequirement(formData)`: FormDataからRequirementオブジェクト構築 → Zodバリデーション → save → revalidatePath → redirect
+- `updateRequirement(formData)`: 既存データマージ → save → revalidatePath → redirect
+- `deleteRequirement(id)`: 削除 → revalidatePath → redirect
+
+## 4. データフロー
+
+### 一覧表示
+
+```
+ブラウザ → /requirements (GET)
+  → RequirementsPage (Server Component)
+    → getAllRequirements()
+      → getRepository() → LocalRequirementRepository
+        → findAll() → .reqord/requirements/req-*.json読み込み
+    → <RequirementTable requirements={data} />
+  → HTML レスポンス
+```
+
+### 新規作成
+
+```
+ブラウザ → フォーム送信 (POST)
+  → createRequirement(formData) [Server Action]
+    → FormData → JSONオブジェクト変換
+    → repo.generateNextId() → "req-000002"
+    → RequirementSchema.safeParse(raw) → バリデーション
+    → repo.save(requirement) → JSON書き込み
+    → repo.saveDescription(id, description) → Markdown書き込み
+    → revalidatePath("/requirements")
+    → redirect(`/requirements/${id}`)
+```
+
+### 編集
+
+```
+ブラウザ → /requirements/req-000001/edit (GET)
+  → EditPage (Server Component)
+    → Promise.all([getRequirementById, getRequirementDescription, getAllRequirements])
+    → <RequirementForm mode="edit" requirement={...} />
+
+ブラウザ → フォーム送信 (POST)
+  → updateRequirement(formData) [Server Action]
+    → 既存データ取得 → マージ → バリデーション → save
+    → revalidatePath → redirect
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **LocalRequirementRepository**: findAll, findById, save, deleteByIdの各メソッド。テスト用一時ディレクトリ使用
+- **reqord-root.ts**: REQORD_ROOT環境変数未設定時のエラー
+- **id-generator.ts**: 次IDの自動採番
+
+### コンポーネントテスト
+
+- **RequirementTable**: propsに基づくテーブル行数・カラム値の検証
+- **RequirementForm**: 各フォーマット選択時の動的フォーム切り替え
+
+### 統合テスト
+
+- Server Actions経由でのCRUD操作の一連フロー
+- CLIで作成した要件がWebUIに表示されること（ファイルシステム共有の検証）
+
+## 6. 技術的決定事項
+
+### Server Componentsによるデータ取得
+
+**決定:** ページコンポーネントはServer Componentとし、データ取得をサーバーサイドで完結
+**理由:** ローカルファイルシステムへのアクセスはサーバーサイドでのみ可能。APIエンドポイントを別途作成する必要がなく、Server Components + Server Actionsで読み書きを完結できる。
+
+### dynamic = "force-dynamic"
+
+**決定:** 全ページで `force-dynamic` を設定し、キャッシュを無効化
+**理由:** ファイルシステムの変更（CLI操作等）を即座に反映する必要がある。静的生成やキャッシュは、外部からのファイル変更を検知できない。
+
+### REQORD_ROOT環境変数
+
+**決定:** `.reqord/` ディレクトリの位置を `REQORD_ROOT` 環境変数で指定
+**理由:** Next.jsのServer Componentは `process.cwd()` がプロジェクトルートを指すため、reqordの対象プロジェクトディレクトリを環境変数で明示的に指定する必要がある。
+
+### CLIとの Repository実装の分離
+
+**決定:** Web版は独自のLocalRequirementRepositoryクラスを持つ（CLI版repositoryと別実装）
+**理由:** CLI版はcwdを引数に取る関数ベース、Web版はREQORD_ROOTを参照するクラスベース。I/Oロジックは類似するが、初期化方法とライフサイクルが異なる。共通化は将来の課題。

--- a/.reqord/specifications/spec-000008.json
+++ b/.reqord/specifications/spec-000008.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000008",
+  "requirementId": "req-000008",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.215Z",
+  "updatedAt": "2026-02-08T14:08:07.215Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000008/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000008/design.md
+++ b/.reqord/specifications/spec-000008/design.md
@@ -1,0 +1,203 @@
+# Requirement Show/Update/Delete - 技術設計書
+
+## 1. 設計概要
+
+要件の詳細表示（show）、フィールド更新（update）、削除（delete）の3コマンドを提供する。spec-000002で定義されたCRUD操作のうち、読み取り以降の操作に特化した設計書であり、各コマンドの入出力仕様、更新時のバリデーション戦略、削除時の安全性確保を詳細化する。既存の `requirement-service.ts` と `requirement.ts` リポジトリを活用する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:
+  commands/req/show.ts     → showRequirement()
+  commands/req/update.ts   → updateRequirement()
+  commands/req/delete.ts   → deleteRequirement()
+      ↓
+Service Layer:
+  services/requirement-service.ts
+    ├── showRequirement(cwd, id) → ShowResult
+    ├── updateRequirement(cwd, id, options) → UpdateResult
+    └── deleteRequirement(cwd, id) → void
+      ↓
+Repository Layer:
+  repositories/requirement.ts
+    ├── findById(cwd, id) → Requirement | null
+    ├── save(cwd, requirement) → void
+    ├── loadDescription(cwd, id) → string | null
+    ├── saveDescription(cwd, id, content) → void
+    └── deleteById(cwd, id) → void
+      ↓
+File System:
+  .reqord/requirements/req-NNNNNN.json
+  .reqord/requirements/req-NNNNNN/description.md
+```
+
+## 3. コンポーネント設計
+
+### 3.1 showコマンド (`commands/req/show.ts`)
+
+**責務:** 指定IDの要件メタデータ全フィールドとdescription.mdの内容を表示。
+
+**入力:**
+- `<id>`: 必須引数（例: `req-000001`）
+- `--json`: オプション。JSON出力（description含む）
+
+**出力（通常モード）:**
+```
+Requirement: req-000001
+
+  Title:      認証機能の実装
+  Status:     draft
+  Priority:   high
+  Format:     user-story
+  Version:    1.0.0
+  Created:    2025-01-01T00:00:00.000Z
+  Updated:    2025-01-01T00:00:00.000Z
+  Criteria:   基準1, 基準2
+
+Description:
+  [description.mdの内容]
+```
+
+**出力（--json）:**
+```json
+{
+  "id": "req-000001",
+  "title": "...",
+  "description": "..."
+}
+```
+
+### 3.2 updateコマンド (`commands/req/update.ts`)
+
+**責務:** 指定IDの要件フィールドを更新。
+
+**入力:**
+- `<id>`: 必須引数
+- `-t, --title <title>`: タイトル更新
+- `-s, --status <status>`: ステータス更新（draft/pending_approval/approved/deprecated）
+- `-p, --priority <priority>`: 優先度更新（low/medium/high）
+- `--patch-file <path>`: JSONファイルによる一括更新
+- `--description-file <path>`: Markdownファイルによるdescription.md更新
+- `--json`: 更新後のRequirementをJSON出力
+
+**オプション必須チェック:** いずれのオプションも指定されない場合はエラー。
+
+**マージ戦略:**
+1. 既存データを取得（before）
+2. `--patch-file` の内容をシャローマージ（許可フィールドのみ）
+3. 個別フラグ（--title, --status, --priority）で上書き
+4. immutableフィールド保持: id, createdAt, files
+5. updatedAtを現在時刻に更新
+6. RequirementSchema.safeParseで全体バリデーション
+7. 保存
+
+**出力:** 変更されたフィールドのbefore → after差分表示。
+
+### 3.3 deleteコマンド (`commands/req/delete.ts`)
+
+**責務:** 指定IDの要件を削除（JSONファイル + 説明文ディレクトリ）。
+
+**入力:**
+- `<id>`: 必須引数
+- `-f, --force`: 確認プロンプトスキップ
+
+**確認フロー:**
+```
+--force未指定:
+  "Are you sure you want to delete req-000001? (y/N) "
+  → y: 削除実行
+  → N/その他: "Cancelled." で終了
+
+--force指定:
+  → 即座に削除実行
+```
+
+**削除対象:**
+- `.reqord/requirements/req-NNNNNN.json`
+- `.reqord/requirements/req-NNNNNN/` ディレクトリ全体（description.md含む）
+
+**エラー処理:** 指定IDが存在しない場合は `Requirement {id} not found.` エラー。
+
+## 4. データフロー
+
+### Show
+
+```
+ユーザー → reqord req show req-000001
+  → showCommand.action(id, { json: false })
+    → showRequirement(cwd, "req-000001")
+      → reqRepo.findById(cwd, "req-000001")
+        → .reqord/requirements/req-000001.json読み込み
+        → RequirementSchema.safeParse → Requirement
+      → reqRepo.loadDescription(cwd, "req-000001")
+        → .reqord/requirements/req-000001/description.md読み込み
+    → ShowResult { requirement, description }
+  → フォーマット済み出力
+```
+
+### Update（複合オプション）
+
+```
+ユーザー → reqord req update req-000001 -t "新タイトル" --patch-file patch.json --description-file desc.md
+  → updateCommand.action(id, options)
+    → fs.readText("patch.json") → patchData
+    → fs.readText("desc.md") → descriptionContent
+    → updateRequirement(cwd, id, { title: "新タイトル", patchData, descriptionContent })
+      → findById → before: { title: "旧タイトル", status: "draft", ... }
+      → merge: { ...before, ...patchData } → { title: "patch内タイトル", ... }
+      → override: title = "新タイトル"（個別フラグ優先）
+      → updatedAt = now()
+      → RequirementSchema.safeParse(merged) → after
+      → reqRepo.save(cwd, after)
+      → reqRepo.saveDescription(cwd, id, descriptionContent)
+    → UpdateResult { before, after, descriptionUpdated: true }
+  → 差分表示:
+    title: 旧タイトル → 新タイトル
+    description.md: updated
+```
+
+### Delete
+
+```
+ユーザー → reqord req delete req-000001
+  → deleteCommand.action(id, { force: false })
+    → confirm("Are you sure you want to delete req-000001?")
+      → "y"
+    → deleteRequirement(cwd, "req-000001")
+      → reqRepo.findById → 存在確認
+      → reqRepo.deleteById(cwd, "req-000001")
+        → fs.remove("req-000001.json")
+        → fs.remove("req-000001/")
+  → "Deleted requirement: req-000001"
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **show**: 存在するID→正常表示、存在しないID→エラー、description.mdなし→descriptionがnull
+- **update**: 各フィールド個別更新、patch-file適用、個別フラグとpatch-fileの優先順位、immutableフィールドの保持、Zodバリデーション失敗
+- **delete**: 存在するID→正常削除、存在しないID→エラー
+
+### 統合テスト
+
+- create → show → update → show（更新反映確認） → delete → show（404確認）
+- --json出力がJSON.parseableであること
+- --force での非対話的削除
+
+## 6. 技術的決定事項
+
+### 確認プロンプトの実装
+
+**決定:** `node:readline/promises` の `createInterface` を使用
+**理由:** 外部ライブラリ不要。Node.js標準APIのみで対話的プロンプトを実現。`--force` オプションでスキップ可能にすることで、スクリプト/AIエージェントからの利用も対応。
+
+### 更新時のZod再検証
+
+**決定:** マージ後のデータ全体をRequirementSchema.safeParseで再検証
+**理由:** patch-fileの内容が不正な場合（型不一致、必須フィールド欠落等）を確実に検出。個別フィールドの型チェックだけでは、discriminatedUnion（format）やネストされたオブジェクト（dependencies）の整合性を保証できない。
+
+### 変更差分の表示
+
+**決定:** before/afterの各フィールドを比較し、変更があったフィールドのみ表示
+**理由:** 全フィールドを表示すると冗長。ユーザーが「何が変わったか」を即座に確認できることが重要。

--- a/.reqord/specifications/spec-000009.json
+++ b/.reqord/specifications/spec-000009.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000009",
+  "requirementId": "req-000009",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.300Z",
+  "updatedAt": "2026-02-08T14:08:07.300Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000009/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000009/design.md
+++ b/.reqord/specifications/spec-000009/design.md
@@ -1,0 +1,211 @@
+# CLIエラーハンドリング統一 - 技術設計書
+
+## 1. 設計概要
+
+reqord CLI全体のエラーハンドリングを統一し、一貫したエラーメッセージ、終了コード、出力先を提供する。`.reqord/` ディレクトリの初期化チェックを共有ミドルウェアとして導入し、各コマンドで繰り返される定型エラー処理を共通化する。エラーメッセージは日本語で提供し、AIエージェント向けには `--json` オプションでの構造化エラー出力もサポートする。本機能は未実装。
+
+## 2. アーキテクチャ
+
+```
+CLI エントリポイント (index.ts)
+    ↓
+  Commander.js グローバルフック / ミドルウェア
+    ↓
+  commands/*/*.ts (各コマンド)
+    ↓ throw
+  共通エラーハンドラ
+    ├── stderr出力（人間向け / --json）
+    ├── exit code設定
+    └── ログ（デバッグ時）
+
+新規ファイル:
+  utils/errors.ts         (エラークラス定義)
+  utils/error-handler.ts  (共通ハンドラ)
+  middleware/reqord-check.ts  (.reqord/存在チェック)
+```
+
+### 既存構造との統合
+
+```
+現状:
+  各コマンド → try/catch → console.error(chalk.red(...)) → process.exitCode = 1
+
+改善後:
+  各コマンド → throw AppError → 共通ハンドラ → 統一フォーマット出力
+```
+
+## 3. コンポーネント設計
+
+### 3.1 エラークラス (`utils/errors.ts` - 新規)
+
+**責務:** アプリケーション固有のエラー型定義。
+
+```typescript
+export class AppError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ErrorCode,
+    public readonly exitCode: number = 1,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+export enum ErrorCode {
+  UNINITIALIZED = "UNINITIALIZED",
+  NOT_FOUND = "NOT_FOUND",
+  VALIDATION_ERROR = "VALIDATION_ERROR",
+  FILE_READ_ERROR = "FILE_READ_ERROR",
+  FILE_WRITE_ERROR = "FILE_WRITE_ERROR",
+  INVALID_ARGUMENT = "INVALID_ARGUMENT",
+  ALREADY_EXISTS = "ALREADY_EXISTS",
+  DEPENDENCY_ERROR = "DEPENDENCY_ERROR",
+}
+```
+
+### 3.2 共通エラーハンドラ (`utils/error-handler.ts` - 新規)
+
+**責務:** エラーの統一的な出力処理。
+
+```typescript
+export function handleError(error: unknown, options?: { json?: boolean }): void {
+  if (error instanceof AppError) {
+    if (options?.json) {
+      // 構造化エラー出力（stdoutではなくstderr）
+      console.error(JSON.stringify({
+        error: true,
+        code: error.code,
+        message: error.message,
+      }));
+    } else {
+      console.error(chalk.red(`エラー: ${error.message}`));
+    }
+    process.exitCode = error.exitCode;
+  } else {
+    // 予期しないエラー
+    console.error(chalk.red(`予期しないエラーが発生しました: ${(error as Error).message}`));
+    process.exitCode = 1;
+  }
+}
+```
+
+### 3.3 .reqord/ 初期化チェックミドルウェア (`middleware/reqord-check.ts` - 新規)
+
+**責務:** `init` 以外のコマンド実行前に `.reqord/` ディレクトリの存在を確認。
+
+```typescript
+export async function ensureReqordInitialized(cwd: string): Promise<void> {
+  const reqordDir = path.join(cwd, REQORD_DIR);
+  if (!(await exists(reqordDir))) {
+    throw new AppError(
+      ".reqord/ ディレクトリが見つかりません。先に 'reqord init' を実行してください。",
+      ErrorCode.UNINITIALIZED,
+    );
+  }
+}
+```
+
+**適用方法:** Commander.jsの `hook("preAction")` またはコマンドアクション冒頭での呼び出し。
+
+### 3.4 エラーパターン定義
+
+| ErrorCode | 状況 | メッセージ例 |
+|-----------|------|-------------|
+| `UNINITIALIZED` | `.reqord/` が存在しない | `.reqord/ ディレクトリが見つかりません。先に 'reqord init' を実行してください。` |
+| `NOT_FOUND` | 指定IDの要件が見つからない | `要件 req-000001 が見つかりません。` |
+| `VALIDATION_ERROR` | Zodバリデーション失敗 | `バリデーションエラー: title は1文字以上必要です。` |
+| `FILE_READ_ERROR` | ファイル読み込み失敗 | `ファイルの読み込みに失敗しました: {path}` |
+| `FILE_WRITE_ERROR` | ファイル書き込み失敗 | `ファイルの書き込みに失敗しました: {path}` |
+| `INVALID_ARGUMENT` | 不正な引数 | `不正な引数です: status は draft, pending_approval, approved, deprecated のいずれかを指定してください。` |
+| `ALREADY_EXISTS` | 既に存在する | `context.json は既に存在します。` |
+| `DEPENDENCY_ERROR` | 依存関係エラー | `存在しない要件 req-999999 を参照しています。` |
+
+### 3.5 終了コード
+
+| コード | 意味 | 使用場面 |
+|-------|------|---------|
+| `0` | 成功 | 正常完了 |
+| `1` | 一般エラー | バリデーション失敗、ファイル不在等 |
+
+## 4. データフロー
+
+### エラーハンドリングフロー（改善後）
+
+```
+ユーザー → reqord req show req-999999
+  → showCommand.action("req-999999")
+    → ensureReqordInitialized(cwd)  ← ミドルウェア
+      → .reqord/ 存在確認 → OK
+    → showRequirement(cwd, "req-999999")
+      → reqRepo.findById(cwd, "req-999999") → null
+      → throw new AppError("要件 req-999999 が見つかりません。", ErrorCode.NOT_FOUND)
+  → handleError(error)
+    → stderr: "エラー: 要件 req-999999 が見つかりません。"
+    → process.exitCode = 1
+```
+
+### 未初期化時のフロー
+
+```
+ユーザー → reqord req list  (init未実行)
+  → listCommand.action()
+    → ensureReqordInitialized(cwd)  ← ミドルウェア
+      → .reqord/ 存在確認 → 不在
+      → throw new AppError("...", ErrorCode.UNINITIALIZED)
+  → handleError(error)
+    → stderr: "エラー: .reqord/ ディレクトリが見つかりません。先に 'reqord init' を実行してください。"
+    → process.exitCode = 1
+```
+
+### --json モードでのエラー
+
+```
+ユーザー → reqord req show req-999999 --json
+  → throw AppError(NOT_FOUND)
+  → handleError(error, { json: true })
+    → stderr: {"error":true,"code":"NOT_FOUND","message":"要件 req-999999 が見つかりません。"}
+    → process.exitCode = 1
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **AppError**: 各ErrorCodeの生成、exitCodeの設定
+- **handleError**: AppError→統一フォーマット出力、非AppError→予期しないエラー出力
+- **ensureReqordInitialized**: .reqord/存在時→正常通過、不在時→AppError(UNINITIALIZED)
+- **--jsonモードでのエラー出力**: stderr出力がJSON.parseableであること
+
+### 統合テスト
+
+- 未初期化状態での各コマンド実行 → 統一エラーメッセージ
+- 存在しないIDでのshow/update/delete → NOT_FOUNDエラー
+- 不正なpatch-file → VALIDATION_ERRORエラー
+- exit code検証: 正常→0、エラー→1
+
+### リグレッションテスト
+
+- 既存コマンドの正常動作が維持されること（エラーハンドリング変更による副作用がないこと）
+
+## 6. 技術的決定事項
+
+### カスタムエラークラスの導入
+
+**決定:** `AppError` クラスにErrorCodeとexitCodeを持たせる
+**理由:** 現状は各コマンドでcatch→console.error→process.exitCodeの定型コードが繰り返されている。エラーの種類を型で区別することで、ハンドラ側で適切な処理（日本語メッセージ、JSON出力切り替え）が可能になる。
+
+### stderrへのエラー出力
+
+**決定:** すべてのエラーメッセージはstderrに出力
+**理由:** stdoutは正常時のデータ出力（特に--jsonモード）に使用する。AIエージェントがstdoutをパースする際にエラーメッセージが混入すると、JSONパースが失敗する。
+
+### 日本語エラーメッセージ
+
+**決定:** エラーメッセージは日本語で提供
+**理由:** reqordの主要ターゲットは日本語プロジェクト（ProjectContextのデフォルト言語がja）。AIエージェント向けにはErrorCodeにより言語非依存の判別が可能。
+
+### Commander.js preAction フックの活用
+
+**決定:** `.reqord/` 初期化チェックをCommander.jsのhookまたは共通関数として実装
+**理由:** 各コマンドのaction内に個別にチェックコードを書くと漏れが生じる。`init` コマンドのみ除外し、他のすべてのコマンドに適用する共通前処理として実装する。

--- a/.reqord/specifications/spec-000010.json
+++ b/.reqord/specifications/spec-000010.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000010",
+  "requirementId": "req-000010",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.385Z",
+  "updatedAt": "2026-02-08T14:08:07.385Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000010/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000010/design.md
+++ b/.reqord/specifications/spec-000010/design.md
@@ -1,0 +1,159 @@
+# Zodバリデーションエラー詳細表示 - 技術設計書
+
+## 1. 設計概要
+
+Zodスキーマのバリデーション失敗時に、ZodError.issuesを解析して人間が読みやすい日本語エラーメッセージを生成する。現状の「Validation error」のような汎用メッセージを、フィールドパス・期待値・実際の値を含む詳細メッセージに置き換える。フォーマット関数は `@reqord/shared` に配置し、CLI・Web両方から利用可能にする。
+
+## 2. アーキテクチャ
+
+```
+Shared:         @reqord/shared
+                  utils/zod-error-formatter.ts (新規)
+                    ↓ 利用
+CLI:            packages/cli
+                  repositories/requirement.ts   (既存修正)
+                  repositories/specification.ts (既存修正)
+                  services/requirement-service.ts (既存修正)
+                    ↓ throw
+                  utils/error-handler.ts (spec-000009で追加予定)
+                    ↓
+                  stderr出力
+
+Web:            packages/web (将来利用)
+```
+
+`@reqord/shared` にフォーマッタを配置することで、CLI・Web・テストなどすべてのパッケージから利用可能にする。既存のバリデーション箇所（`safeParse` の `error.message` を使用している箇所）を一括でフォーマッタ呼び出しに置き換える。
+
+## 3. コンポーネント設計
+
+### 3.1 ZodErrorフォーマッタ (`@reqord/shared/utils/zod-error-formatter.ts` - 新規)
+
+**責務:** ZodErrorオブジェクトから人間可読な日本語エラーメッセージ文字列を生成。
+
+```typescript
+import { ZodError, type ZodIssue } from "zod";
+
+export interface FormatOptions {
+  prefix?: string;   // 各行の接頭辞（デフォルト: "- "）
+  separator?: string; // 行区切り（デフォルト: "\n"）
+}
+
+export function formatZodError(error: ZodError, options?: FormatOptions): string;
+export function formatZodIssue(issue: ZodIssue): string;
+```
+
+**出力形式:**
+```
+- status: 不正な値 'unknown'（期待値: draft, approved, pending_approval, deprecated）
+- dependencies.blockedBy[0]: 文字列が必要です（実際の型: number）
+- title: 1文字以上の文字列が必要です
+- estimatedHours: 正の数値が必要です
+```
+
+**対応するZodIssueCode:**
+- `invalid_type`: 型不一致 → `"{path}: {expected}が必要です（実際の型: {received}）"`
+- `invalid_enum_value`: enum不一致 → `"{path}: 不正な値 '{received}'（期待値: {options}）"`
+- `too_small` / `too_big`: 範囲外 → `"{path}: {minimum/maximum}以上/以下が必要です"`
+- `invalid_string`: 正規表現不一致 → `"{path}: 形式が不正です"`
+- `unrecognized_keys`: 未知のキー → `"{path}: 不明なフィールド '{keys}'"`
+- その他: `"{path}: {message}"` （Zodのデフォルトメッセージをフォールバック）
+
+### 3.2 フィールドパス解決
+
+**責務:** `ZodIssue.path` 配列をドット区切りのパス文字列に変換。
+
+```typescript
+// path: ["dependencies", "blockedBy", 0] → "dependencies.blockedBy[0]"
+function formatPath(path: (string | number)[]): string;
+```
+
+- 文字列要素: ドットで結合
+- 数値要素: ブラケット表記 `[N]`
+- 空配列: `"(root)"` を返す
+
+### 3.3 既存コード修正箇所
+
+**requirement.ts リポジトリ:**
+```typescript
+// Before:
+throw new Error(`Invalid requirement ${id}: ${result.error.message}`);
+
+// After:
+throw new Error(`要件 ${id} のバリデーションエラー:\n${formatZodError(result.error)}`);
+```
+
+**specification.ts リポジトリ:**
+```typescript
+// Before:
+throw new Error(`Invalid specification ${id}: ${result.error.message}`);
+
+// After:
+throw new Error(`仕様 ${id} のバリデーションエラー:\n${formatZodError(result.error)}`);
+```
+
+**requirement-service.ts:**
+```typescript
+// Before:
+throw new Error(`Validation failed: ${parseResult.error.message}`);
+
+// After:
+throw new Error(`バリデーションエラー:\n${formatZodError(parseResult.error)}`);
+```
+
+## 4. データフロー
+
+### バリデーションエラー発生時
+
+```
+ユーザー → reqord req update req-000001 --patch-file bad.json
+  → updateRequirement(cwd, id, options)
+    → RequirementSchema.safeParse(merged)
+      → { success: false, error: ZodError }
+    → formatZodError(error) → 日本語メッセージ文字列生成
+      → issues[0]: { code: "invalid_enum_value", path: ["status"], received: "unknown", options: [...] }
+        → "- status: 不正な値 'unknown'（期待値: draft, approved, pending_approval, deprecated）"
+      → issues[1]: { code: "too_small", path: ["title"], minimum: 1, type: "string" }
+        → "- title: 1文字以上の文字列が必要です"
+    → throw Error("バリデーションエラー:\n- status: ...\n- title: ...")
+  → handleError(error)
+    → stderr: "エラー: バリデーションエラー:\n  - status: 不正な値 'unknown'（期待値: ...）\n  - title: ..."
+```
+
+### ネストフィールドのエラー
+
+```
+不正なJSON: { "dependencies": { "blockedBy": [123] } }
+  → ZodIssue: { code: "invalid_type", path: ["dependencies", "blockedBy", 0], expected: "string", received: "number" }
+  → "- dependencies.blockedBy[0]: 文字列が必要です（実際の型: number）"
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **formatZodError**: 各ZodIssueCode（invalid_type, invalid_enum_value, too_small, too_big, invalid_string, unrecognized_keys）に対する出力検証
+- **formatPath**: 空配列、文字列のみ、数値混在、深いネストのパス変換
+- **複数エラー同時表示**: issuesが3件以上ある場合にすべてが出力されること
+- **フォーマットオプション**: prefix、separator指定時の出力変化
+
+### 統合テスト
+
+- RequirementSchemaに不正なデータを渡した際、フォーマット済みエラーが表示されること
+- `reqord req update` で不正なpatch-fileを渡した際のエラー出力検証
+
+## 6. 技術的決定事項
+
+### フォーマッタの配置先
+
+**決定:** `@reqord/shared/utils/zod-error-formatter.ts` に配置
+**理由:** CLI以外のパッケージ（Web UI等）でもZodバリデーションエラーの表示が必要になる。共通パッケージに置くことでDRYを維持する。
+
+### 全エラー同時表示
+
+**決定:** ZodError.issues の全件をフォーマットして表示（最初の1件だけではない）
+**理由:** JSONファイルの手動修正時、1つずつエラーを修正→再実行のサイクルは非効率。全エラーを一括表示することで、修正回数を最小化する。
+
+### 日本語メッセージ
+
+**決定:** フォーマット済みメッセージは日本語で出力
+**理由:** reqordのプロジェクト全体方針として日本語を主言語としている（ProjectContextのデフォルト言語がja）。将来的にi18n対応する場合はフォーマッタにlocaleオプションを追加可能。

--- a/.reqord/specifications/spec-000011.json
+++ b/.reqord/specifications/spec-000011.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000011",
+  "requirementId": "req-000011",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.471Z",
+  "updatedAt": "2026-02-08T14:08:07.471Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000011/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000011/design.md
+++ b/.reqord/specifications/spec-000011/design.md
@@ -1,0 +1,231 @@
+# Requirement承認フロー (GitHub PR連携) - 技術設計書
+
+## 1. 設計概要
+
+要件の承認プロセスをGitHub PR（Pull Request）ベースで管理する。`reqord req approve <id>` コマンドにより、Gitブランチ作成・要件ステータス変更・PR自動生成を一括実行する。CODEOWNERSファイルと連携してレビュアーを自動アサインし、PRマージをトリガーとしてステータスをapprovedに更新する。承認情報はcurrentApproval・versionHistoryフィールドに記録する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/req/approve.ts     (新規)
+                    ↓
+Service Layer:  services/approval-service.ts (新規 - 共通承認サービス)
+                services/requirement-service.ts (既存拡張)
+                    ↓
+Repository:     repositories/requirement.ts  (既存)
+                repositories/git.ts          (新規 - Git操作)
+                repositories/github.ts       (新規 - GitHub CLI操作)
+                    ↓
+External:       git CLI / gh CLI
+                    ↓
+Storage:        .reqord/requirements/req-NNNNNN.json
+                GitHub PR
+```
+
+承認フローは後続のSpecification承認（spec-000015）でも同一パターンを使用するため、共通のapproval-serviceとして設計する。Git/GitHub操作はリポジトリ層に隔離し、テスト時にモック可能にする。
+
+## 3. コンポーネント設計
+
+### 3.1 approveコマンド (`commands/req/approve.ts` - 新規)
+
+**責務:** CLIエントリポイント。承認対象のID受け取り、サービスへの委譲。
+
+```
+reqord req approve <id> [--dry-run]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<id>` | 承認対象の要件ID（req-NNNNNN） |
+| `--dry-run` | 実際のGit/GitHub操作を行わず、実行予定の内容を表示 |
+
+### 3.2 ApprovalService (`services/approval-service.ts` - 新規)
+
+**責務:** 承認フローの共通ロジック。Requirement/Specificationの両方で利用。
+
+```typescript
+export interface ApprovalTarget {
+  type: "requirement" | "specification";
+  id: string;
+  version: string;
+  status: Status;
+  title: string;
+  files: string[];  // PRに含めるファイルパス
+}
+
+export interface ApprovalResult {
+  branchName: string;
+  prNumber: number;
+  prUrl: string;
+}
+
+export interface ApprovalOptions {
+  dryRun?: boolean;
+}
+
+export async function startApproval(
+  cwd: string,
+  target: ApprovalTarget,
+  options?: ApprovalOptions,
+): Promise<ApprovalResult>;
+```
+
+**処理フロー:**
+1. 前提条件チェック（status === "draft"）
+2. ステータスをpending_approvalに更新
+3. Gitブランチ作成（命名規則に従う）
+4. 変更をコミット
+5. ブランチをプッシュ
+6. gh CLI でPR作成
+7. 結果を返却
+
+### 3.3 ブランチ命名規則
+
+```
+reqord/req-<id>-approve-v<version>
+例: reqord/req-000011-approve-v1.0.0
+```
+
+### 3.4 GitRepository (`repositories/git.ts` - 新規)
+
+**責務:** Git CLI操作の抽象化。
+
+```typescript
+export async function createBranch(name: string): Promise<void>;
+export async function checkout(branchName: string): Promise<void>;
+export async function add(files: string[]): Promise<void>;
+export async function commit(message: string): Promise<void>;
+export async function push(branchName: string): Promise<void>;
+export async function getCurrentBranch(): Promise<string>;
+export async function getCurrentCommitHash(): Promise<string>;
+```
+
+内部では `child_process.execFile` を使用してgitコマンドを実行する。
+
+### 3.5 GitHubRepository (`repositories/github.ts` - 新規)
+
+**責務:** gh CLI操作の抽象化。
+
+```typescript
+export interface CreatePrOptions {
+  title: string;
+  body: string;
+  base?: string;    // デフォルト: main
+  head: string;
+  draft?: boolean;
+}
+
+export interface PrInfo {
+  number: number;
+  url: string;
+}
+
+export async function createPullRequest(options: CreatePrOptions): Promise<PrInfo>;
+export async function getPullRequest(number: number): Promise<PrInfo>;
+```
+
+### 3.6 RequirementSchema拡張 (`@reqord/shared/schemas/requirement.ts`)
+
+**追加フィールド:**
+
+```typescript
+currentApproval: z.object({
+  version: z.string(),
+  phase: z.enum(["requirement", "specification"]),
+  prNumber: z.number(),
+  prUrl: z.string(),
+  approvedBy: z.array(z.string()),
+  approvedAt: z.string().optional(),
+}).optional(),
+```
+
+### 3.7 PR本文テンプレート
+
+```markdown
+## 要件承認依頼
+
+| フィールド | 値 |
+|-----------|------|
+| ID | {id} |
+| タイトル | {title} |
+| バージョン | {version} |
+| 優先度 | {priority} |
+
+### 成功基準
+{successCriteria}
+
+### 変更内容
+status: draft → pending_approval
+
+> このPRをマージすると、要件のステータスが `approved` に更新されます。
+```
+
+## 4. データフロー
+
+### 承認開始フロー
+
+```
+ユーザー → reqord req approve req-000011
+  → approveCommand.action("req-000011")
+    → requirementService.showRequirement(cwd, "req-000011")
+      → 存在確認 + 現在のstatus確認
+    → 前提条件チェック: status === "draft" → OK
+    → ApprovalTarget構築
+    → approvalService.startApproval(cwd, target)
+      → requirementService.updateRequirement(cwd, id, { status: "pending_approval" })
+      → gitRepo.createBranch("reqord/req-000011-approve-v1.0.0")
+      → gitRepo.checkout("reqord/req-000011-approve-v1.0.0")
+      → gitRepo.add([".reqord/requirements/req-000011.json"])
+      → gitRepo.commit("chore(reqord): request approval for req-000011")
+      → gitRepo.push("reqord/req-000011-approve-v1.0.0")
+      → githubRepo.createPullRequest({ title, body, head })
+        → gh pr create --title "..." --body "..." --head "..."
+      → return { branchName, prNumber, prUrl }
+  → 成功メッセージ表示（PR URL含む）
+```
+
+### PRマージ後のステータス更新
+
+PRマージ後のステータス更新は、以下のいずれかの方法で実行する:
+
+1. **手動更新（Phase 1）:** `reqord req update <id> --status approved`
+2. **GitHub Actions連携（Phase 2）:** PRマージイベントをトリガーにワークフローで自動更新
+
+Phase 1では手動更新を前提とし、Phase 2でGitHub Actionsによる自動化を追加する。
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **approval-service**: 前提条件チェック（draft以外のステータスでエラー）、ブランチ名生成、PR本文生成
+- **git repository**: 各Git操作のコマンド引数検証（execFileのモック）
+- **github repository**: gh CLIのコマンド引数検証（execFileのモック）
+- **dry-runモード**: 実際のGit/GitHub操作が呼ばれないこと
+
+### 統合テスト
+
+- Gitリポジトリ内での一連フロー: approve → ブランチ作成 → コミット確認
+- Git未初期化環境でのエラーハンドリング
+- gh CLI未インストール時のエラーハンドリング
+
+## 6. 技術的決定事項
+
+### 共通承認サービスの設計
+
+**決定:** approval-serviceをRequirement/Specification共通の抽象的なサービスとして設計
+**理由:** spec-000015（Specification承認フロー）で同一パターンを使用する。ApprovalTargetインターフェースにより、承認対象の種類を意識せずに同一フローを実行可能。
+
+### Git/GitHub操作のリポジトリ層隔離
+
+**決定:** git/gh CLIの操作をリポジトリ層に隔離し、child_process.execFileで実行
+**理由:** テスト時のモック化が容易。また、将来的にOctokit.jsへの移行が必要になった場合も、リポジトリ層の差し替えのみで対応可能。
+
+### PRマージ後の手動更新（Phase 1）
+
+**決定:** Phase 1ではPRマージ後のステータス更新を手動で行い、GitHub Actions連携はPhase 2で対応
+**理由:** GitHub Actionsワークフローの設計・テストには追加の複雑さがある。まずCLI単体で完結するフローを確立し、自動化は段階的に導入する。
+
+### gh CLI依存
+
+**決定:** GitHub操作にはgh CLIを使用（Octokit.jsではなく）
+**理由:** reqordの設計方針としてgh CLIを主要なGitHubインテグレーション手段としている。認証管理がgh CLI側で完結し、追加のトークン管理が不要。

--- a/.reqord/specifications/spec-000012.json
+++ b/.reqord/specifications/spec-000012.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000012",
+  "requirementId": "req-000012",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.554Z",
+  "updatedAt": "2026-02-08T14:08:07.554Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000012/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000012/design.md
+++ b/.reqord/specifications/spec-000012/design.md
@@ -1,0 +1,253 @@
+# 影響範囲分析 - 技術設計書
+
+## 1. 設計概要
+
+要件変更時の影響範囲を自動的に分析し、関連するSpecification・Issue・Requirementを特定する。依存グラフ（blockedBy, blocks, relatedTo）を走査して波及先を検出し、必要に応じてGitHub Issue/PRへ通知コメントを送信する。影響範囲の分析結果はRequirement JSONのimpactフィールドに記録し、`--json` / `--dry-run` オプションでCI/CD連携にも対応する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/impact/analyze.ts   (新規)
+                commands/impact/notify.ts    (新規)
+                    ↓
+Service Layer:  services/impact-service.ts   (新規)
+                    ↓
+Repository:     repositories/requirement.ts  (既存)
+                repositories/specification.ts (既存)
+                repositories/github.ts       (spec-000011で追加)
+                    ↓
+External:       gh CLI (通知用)
+                    ↓
+Storage:        .reqord/requirements/req-NNNNNN.json (impactフィールド)
+                GitHub Issues / PRs (コメント)
+```
+
+依存グラフの走査はサービス層で行い、GitHub通知はリポジトリ層のgh CLI操作に委譲する。分析と通知は別コマンドに分離し、分析結果の確認後に明示的に通知を実行するワークフローを提供する。
+
+## 3. コンポーネント設計
+
+### 3.1 analyzeコマンド (`commands/impact/analyze.ts` - 新規)
+
+**責務:** 影響範囲分析の実行と結果表示。
+
+```
+reqord impact analyze <id> [--json] [--depth <n>]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<id>` | 分析起点の要件ID（req-NNNNNN） |
+| `--json` | 構造化JSON出力 |
+| `--depth <n>` | 依存走査の最大深度（デフォルト: 無制限） |
+
+**表示形式（テーブル）:**
+```
+影響範囲分析: req-000011
+
+直接影響:
+  ID           種類           関係         タイトル
+  req-000012   Requirement    blockedBy    影響範囲分析
+  req-000015   Requirement    blockedBy    Specification承認フロー
+
+間接影響（depth: 2）:
+  ID           種類           経由         タイトル
+  req-000016   Requirement    req-000015   GitHub Issue生成
+
+関連Specification:
+  ID           要件ID         ステータス
+  spec-000011  req-000011     draft
+```
+
+### 3.2 notifyコマンド (`commands/impact/notify.ts` - 新規)
+
+**責務:** 影響先へのGitHub通知送信。
+
+```
+reqord impact notify <id> [--dry-run] [--message <text>]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<id>` | 通知起点の要件ID |
+| `--dry-run` | 通知内容をプレビュー表示（実際に送信しない） |
+| `--message <text>` | カスタム通知メッセージ |
+
+### 3.3 ImpactService (`services/impact-service.ts` - 新規)
+
+**責務:** 依存グラフ走査、影響範囲計算、通知メッセージ生成。
+
+```typescript
+export interface ImpactAnalysis {
+  sourceId: string;
+  directImpacts: ImpactEntry[];
+  indirectImpacts: ImpactEntry[];
+  relatedSpecifications: SpecificationRef[];
+  circularDependencies: string[][];
+  analyzedAt: string;
+}
+
+export interface ImpactEntry {
+  id: string;
+  type: "requirement" | "specification";
+  relation: "blockedBy" | "blocks" | "relatedTo";
+  depth: number;
+  path: string[];  // 到達経路: ["req-000011", "req-000015", "req-000016"]
+  title: string;
+}
+
+export interface SpecificationRef {
+  id: string;
+  requirementId: string;
+  status: Status;
+}
+
+export async function analyzeImpact(
+  cwd: string,
+  id: string,
+  options?: { maxDepth?: number },
+): Promise<ImpactAnalysis>;
+
+export async function notifyImpact(
+  cwd: string,
+  id: string,
+  options?: { dryRun?: boolean; message?: string },
+): Promise<NotifyResult>;
+```
+
+### 3.4 依存グラフ走査アルゴリズム
+
+**BFS（幅優先探索）による波及分析:**
+
+```typescript
+function traverseDependencyGraph(
+  startId: string,
+  allRequirements: Map<string, Requirement>,
+  maxDepth?: number,
+): ImpactEntry[] {
+  const queue: Array<{ id: string; depth: number; path: string[] }> = [];
+  const visited = new Set<string>();
+  const results: ImpactEntry[] = [];
+
+  // 起点の直接依存を追加
+  const startReq = allRequirements.get(startId);
+  for (const depId of startReq.dependencies.blocks) {
+    queue.push({ id: depId, depth: 1, path: [startId, depId] });
+  }
+  // relatedToも走査対象
+  for (const depId of startReq.dependencies.relatedTo) {
+    queue.push({ id: depId, depth: 1, path: [startId, depId] });
+  }
+
+  while (queue.length > 0) {
+    const { id, depth, path } = queue.shift()!;
+    if (visited.has(id)) continue;
+    if (maxDepth && depth > maxDepth) continue;
+    visited.add(id);
+    // results追加 + 次のblocks/relatedToをキューに追加
+  }
+
+  return results;
+}
+```
+
+**循環依存検出:** 既存のvalidation-serviceの `checkCircularDependencies` ロジックを再利用。
+
+### 3.5 RequirementSchema拡張
+
+**追加フィールド:**
+
+```typescript
+impact: z.object({
+  directCount: z.number(),
+  indirectCount: z.number(),
+  lastAnalyzedAt: z.string(),
+  affectedIds: z.array(z.string()),
+}).optional(),
+```
+
+### 3.6 通知コメントテンプレート
+
+```markdown
+**reqord影響範囲通知**
+
+要件 `{sourceId}` ({title}) が変更されました。
+この{type}は影響を受ける可能性があります。
+
+**関係:** {relation}
+**経路:** {path}
+
+{customMessage}
+```
+
+## 4. データフロー
+
+### 影響分析フロー
+
+```
+ユーザー → reqord impact analyze req-000011
+  → analyzeCommand.action("req-000011")
+    → impactService.analyzeImpact(cwd, "req-000011")
+      → reqRepo.findAll(cwd) → 全要件取得
+      → specRepo.findAll(cwd) → 全仕様取得
+      → 依存グラフ構築（Map<id, Requirement>）
+      → BFS走査: req-000011 の blocks → [req-000012, req-000015]
+        → req-000015 の blocks → [req-000016]
+      → relatedTo走査
+      → 関連Specification検索（requirementIdでフィルタ）
+      → 循環依存チェック
+      → ImpactAnalysis構築
+    → requirementService.updateRequirement(cwd, id, { patchData: { impact } })
+  → テーブル表示 or JSON出力
+```
+
+### 通知フロー
+
+```
+ユーザー → reqord impact notify req-000011 --message "優先度変更"
+  → notifyCommand.action("req-000011", { message: "優先度変更" })
+    → impactService.analyzeImpact(cwd, "req-000011") → 影響先取得
+    → 各影響先に対して:
+      → 通知コメント生成
+      → githubRepo.createIssueComment(issueNumber, comment) or
+        githubRepo.createPrComment(prNumber, comment)
+    → 通知結果サマリー表示
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **依存グラフ走査**: 線形依存（A→B→C）、分岐依存（A→B, A→C）、ダイヤモンド依存（A→B→D, A→C→D）
+- **循環依存検出**: A→B→C→A のケースで循環が検出されること
+- **maxDepth制限**: depth=1で間接影響が含まれないこと
+- **Specification関連付け**: requirementIdによる正確なフィルタリング
+- **通知メッセージ生成**: テンプレート変数が正しく置換されること
+- **影響先が0件**: 空のImpactAnalysisが返ること
+
+### 統合テスト
+
+- 複数要件の依存関係を構築し、analyse → notify の一連フロー検証
+- `--dry-run` モードでGitHub API呼び出しが行われないこと
+- `--json` 出力がJSON.parseableであること
+
+## 6. 技術的決定事項
+
+### BFS vs DFS
+
+**決定:** BFS（幅優先探索）を使用
+**理由:** 影響の直接度（depth）を正確に測定するにはBFSが適切。DFSでは最短経路が保証されず、depth表示が不正確になる可能性がある。
+
+### 分析と通知の分離
+
+**決定:** `analyze` と `notify` を別コマンドに分離
+**理由:** 分析結果の確認なしに自動通知することは、不要な通知の発生リスクがある。Human-in-the-loopの原則に従い、分析結果を確認してから明示的に通知を実行するワークフローとする。
+
+### impactフィールドの永続化
+
+**決定:** 分析結果をRequirement JSONのimpactフィールドに記録
+**理由:** 分析は計算コストがかかるため、結果をキャッシュすることで繰り返し表示時のパフォーマンスを向上させる。lastAnalyzedAtで鮮度を管理し、依存関係変更時に再分析を促す。
+
+### relatedToの走査
+
+**決定:** relatedToも走査対象に含める（blockedBy/blocksだけでなく）
+**理由:** relatedToは「関連があるが直接の依存ではない」関係を示す。変更の影響は間接的にも波及する可能性があるため、通知対象に含めるべき。ただし、走査の深度はrelatedTo経由では1（直接のみ）に制限する。

--- a/.reqord/specifications/spec-000013.json
+++ b/.reqord/specifications/spec-000013.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000013",
+  "requirementId": "req-000013",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.639Z",
+  "updatedAt": "2026-02-08T14:08:07.639Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000013/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000013/design.md
+++ b/.reqord/specifications/spec-000013/design.md
@@ -1,0 +1,183 @@
+# Specification CRUD - 技術設計書
+
+## 1. 設計概要
+
+要件（Requirement）に対応する仕様書（Specification）のCRUD操作をCLIコマンドとして提供する。各仕様はJSON（メタデータ）とMarkdown（設計文書）のハイブリッドストレージに保存され、Requirementとの1:N関係で管理される。本機能は既に実装済みであり、`commands/spec/{create,list,show,design}.ts`、`services/specification-service.ts`、`repositories/specification.ts` で構成される。この設計書は既存実装のアーキテクチャを文書化する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/spec/create.ts   (実装済み)
+                commands/spec/list.ts     (実装済み)
+                commands/spec/show.ts     (実装済み)
+                commands/spec/design.ts   (実装済み)
+                    ↓
+Service Layer:  services/specification-service.ts (実装済み)
+                    ↓ 依存
+                repositories/requirement.ts      (要件の存在確認)
+                    ↓
+Repository:     repositories/specification.ts    (実装済み)
+                    ↓
+File System:    repositories/file-system.ts      (実装済み)
+                    ↓
+Storage:        .reqord/specifications/
+                  ├── spec-NNNNNN.json          (メタデータ)
+                  └── spec-NNNNNN/
+                      └── design.md             (設計文書)
+
+Shared:         @reqord/shared
+                  schemas/specification.ts       (SpecificationSchema)
+                  constants/paths.ts             (SPECIFICATIONS_DIR)
+```
+
+Requirement CRUDと同様の3層構成。Command層はCommander.jsによるCLIインターフェースに専念し、ビジネスロジックはService層に委譲する。Specification作成時にはRequirementの存在確認を行い、トレーサビリティを確保する。
+
+## 3. コンポーネント設計
+
+### 3.1 コマンド群 (`commands/spec/*.ts` - 実装済み)
+
+**責務:** CLIオプション解析、ユーザー入出力、サービス呼び出し。
+
+| コマンド | 引数・オプション | 出力 |
+|---------|-----------------|------|
+| `create <req-id>` | Requirement ID（必須） | 作成したSpec ID・メタデータ・design.mdパス表示 |
+| `list` | `-s, --status`, `-r, --requirement`, `--json` | cli-table3によるテーブル表示 |
+| `show <id>` | `--json` | メタデータ全フィールド + design.md内容表示 |
+| `design <id>` | `--content-file <path>` | design.mdパス表示 or ファイル更新 |
+
+### 3.2 SpecificationService (`services/specification-service.ts` - 実装済み)
+
+**責務:** CRUD操作のビジネスロジック。
+
+- `createSpecification(cwd, { requirementId })`:
+  - Requirementの存在確認（reqRepo.findById）
+  - ID自動採番（spec-NNNNNN形式）
+  - Specificationオブジェクト構築
+  - ディレクトリ作成 + JSON保存
+  - design.mdテンプレート配置（プロジェクトカスタム or デフォルト）
+
+- `listSpecifications(cwd, { status?, requirementId? })`:
+  - 全件取得 + status/requirementIdフィルタリング
+
+- `showSpecification(cwd, id)`:
+  - メタデータ + design.md読み込み
+
+- `updateSpecDesign(cwd, id, { content? })`:
+  - design.mdの内容更新
+  - updatedAt自動更新
+  - content未指定時はファイルパスのみ返却
+
+### 3.3 SpecificationRepository (`repositories/specification.ts` - 実装済み)
+
+**責務:** ファイルI/O。Zodバリデーション付きread、JSON/Markdown write。
+
+- `ensureSpecDir(cwd, id)`: spec-NNNNNNディレクトリ作成
+- `save(cwd, specification)`: spec-NNNNNN.jsonへJSON書き込み
+- `saveFile(cwd, id, filename, content)`: 任意ファイルへテキスト書き込み
+- `loadFile(cwd, id, filename)`: ファイルテキスト読み込み
+- `findById(cwd, id)`: JSON読み込み + SpecificationSchema.safeParse
+- `findAll(cwd)`: `spec-\d{6}\.json`パターンマッチで全件取得
+- `deleteById(cwd, id)`: JSONファイル + ディレクトリの再帰削除
+
+### 3.4 SpecificationSchema (`@reqord/shared/schemas/specification.ts` - 実装済み)
+
+```typescript
+export const SpecificationSchema = z.object({
+  id: z.string().regex(/^spec-\d{6}$/),
+  requirementId: z.string().regex(/^req-\d{6}$/),
+  version: z.string().default("1.0.0"),
+  status: StatusSchema.default("draft"),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  versionHistory: z.array(VersionHistoryEntrySchema).default([]),
+  files: z.object({
+    design: z.string(),
+    supplementary: z.array(z.string()).default([]),
+  }),
+});
+```
+
+### 3.5 ID自動採番 (`utils/spec-id-generator.ts` - 実装済み)
+
+**責務:** 既存spec-NNNNNN.jsonファイル名をスキャンし、最大番号+1で次IDを生成。
+
+- パターン: `spec-NNNNNN`（6桁ゼロパディング）
+- 既存ファイルがない場合は `spec-000001` から開始
+
+### 3.6 テンプレート管理 (`utils/templates.ts` - 既存)
+
+- `loadProjectTemplate(cwd, "specification-design.md")`: プロジェクトカスタムテンプレート読み込み
+- `DEFAULT_SPECIFICATION_DESIGN_TEMPLATE`: テンプレート未カスタマイズ時のデフォルト
+- テンプレート変数: `{{id}}`, `{{requirementId}}`
+
+## 4. データフロー
+
+### Create
+
+```
+ユーザー → reqord spec create req-000013
+  → specCreateCommand.action("req-000013")
+    → createSpecification(cwd, { requirementId: "req-000013" })
+      → reqRepo.findById(cwd, "req-000013") → Requirement存在確認
+      → generateNextSpecId(cwd) → "spec-000013"
+      → Specificationオブジェクト構築
+      → specRepo.ensureSpecDir(cwd, "spec-000013")
+      → specRepo.save(cwd, specification) → spec-000013.json書き込み
+      → loadProjectTemplate(cwd, "specification-design.md") → テンプレート取得
+      → テンプレート変数置換（{{id}}, {{requirementId}}）
+      → specRepo.saveFile(cwd, "spec-000013", "design.md", content)
+  → 成功メッセージ: "Created specification: spec-000013"
+  → メタデータ表示 + design.mdパス
+```
+
+### Design更新
+
+```
+ユーザー → reqord spec design spec-000013 --content-file ./new-design.md
+  → specDesignCommand.action("spec-000013", { contentFile: "./new-design.md" })
+    → readFile("./new-design.md") → 新しいdesign.md内容
+    → updateSpecDesign(cwd, "spec-000013", { content })
+      → specRepo.findById(cwd, "spec-000013") → 存在確認
+      → specRepo.saveFile(cwd, "spec-000013", "design.md", content)
+      → specRepo.save(cwd, { ...spec, updatedAt: now })
+  → 成功メッセージ: "Updated design for spec-000013"
+```
+
+## 5. テスト方針
+
+### ユニットテスト（実装済み: specification-service.test.ts）
+
+- **createSpecification**: Requirement存在確認、ID自動採番、テンプレート適用
+- **listSpecifications**: status/requirementIdフィルタリング
+- **showSpecification**: メタデータ + design.md読み込み
+- **updateSpecDesign**: content指定時のファイル更新、未指定時のスキップ
+- **存在しないRequirement**: エラーが投げられること
+- **存在しないSpecification**: show/designでエラーが投げられること
+
+### 統合テスト
+
+- 一時ディレクトリで create → list → show → design更新 の一連フロー
+- 複数Specificationの同一Requirementへの関連付け
+- --jsonオプションでの出力フォーマット検証
+
+## 6. 技術的決定事項
+
+### RequirementとSpecificationの1:N関係
+
+**決定:** 1つのRequirementに対して複数のSpecificationを作成可能
+**理由:** 1つの要件に対して複数の設計アプローチ（比較検討）や、段階的な詳細化が必要になるケースがある。requirementIdフィールドにより追跡可能性を確保。
+
+### design.md単独のテンプレート構成
+
+**決定:** Specification作成時にdesign.mdのみを生成（research.md等は将来拡張）
+**理由:** 最小限の構成で早期にリリースし、フィードバックを得てから拡張する。supplementary配列により、将来的な追加ファイルへの対応は可能。
+
+### テンプレートのカスタマイズ戦略
+
+**決定:** `.reqord/settings/templates/specification-design.md` が存在すればそれを使用、なければハードコードされたデフォルトを使用
+**理由:** Requirement CRUDと同一のテンプレート管理パターンを踏襲。プロジェクト固有のテンプレートをGitで管理可能にしつつ、初期セットアップの手間を削減。
+
+### ファイル操作の汎用化
+
+**決定:** specRepo.saveFile/loadFileは汎用的なファイル名を受け取る設計
+**理由:** design.md以外のファイル（research.md, architecture.mmd等）を将来追加する際に、リポジトリ層の変更が不要。

--- a/.reqord/specifications/spec-000014.json
+++ b/.reqord/specifications/spec-000014.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000014",
+  "requirementId": "req-000014",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.721Z",
+  "updatedAt": "2026-02-08T14:08:07.721Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000014/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000014/design.md
+++ b/.reqord/specifications/spec-000014/design.md
@@ -1,0 +1,252 @@
+# 設計検証・要件カバレッジ - 技術設計書
+
+## 1. 設計概要
+
+Specificationのdesign.mdがプロジェクトの設計原則（アーキテクチャパターン、命名規則、依存関係ルール）に準拠しているかをルールベースで自動検証する。また、Requirementの成功基準がSpecificationでカバーされているかを分析し、カバレッジ状況を可視化する。AIは使用せず、ProjectContextの技術情報と構造情報に基づく静的チェックを行う。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/spec/validate.ts   (新規)
+                commands/spec/coverage.ts   (新規)
+                    ↓
+Service Layer:  services/spec-validation-service.ts (新規)
+                services/coverage-service.ts        (新規)
+                    ↓
+Repository:     repositories/specification.ts  (既存)
+                repositories/requirement.ts    (既存)
+                repositories/project-context.ts (既存)
+                    ↓
+Shared:         @reqord/shared
+                  schemas/specification.ts     (拡張: designValidation)
+                  schemas/project-context.ts   (既存: files.technical, files.structure)
+```
+
+ProjectContextのtechnical.md（技術スタック・アーキテクチャパターン）とstructure.md（ディレクトリ構造・命名規則）を参照して検証ルールを構築する。検証結果はSpecification JSONのdesignValidationフィールドに永続化する。
+
+## 3. コンポーネント設計
+
+### 3.1 validateコマンド (`commands/spec/validate.ts` - 新規)
+
+**責務:** 設計検証の実行と結果表示。
+
+```
+reqord spec validate <id> [--json] [--fix]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<id>` | 検証対象のSpecification ID |
+| `--json` | 構造化JSON出力 |
+| `--fix` | 自動修正可能な問題を修正（将来拡張） |
+
+**表示形式:**
+```
+設計検証: spec-000014
+
+  [PASS] アーキテクチャパターン整合性
+  [WARN] 命名規則: "ImpactService" → プロジェクト規則では接尾辞 "Service" を使用 ✓
+  [FAIL] 依存方向: Service層からCommand層への参照が検出されました
+         → design.md L42: "import { specCreateCommand } from ..."
+
+検証結果: 1 error, 1 warning, 1 passed
+```
+
+### 3.2 coverageコマンド (`commands/spec/coverage.ts` - 新規)
+
+**責務:** 要件カバレッジの分析と表示。
+
+```
+reqord spec coverage [<req-id>] [--json]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `[<req-id>]` | 特定要件のカバレッジ表示（省略時: 全要件） |
+| `--json` | 構造化JSON出力 |
+
+**表示形式:**
+```
+要件カバレッジ:
+
+  ID           タイトル                   カバレッジ    Spec数
+  req-000001   CLI初期化コマンド          covered       1
+  req-000002   Requirement CRUD          covered       1
+  req-000010   Zodバリデーション詳細表示   not-covered   0
+  req-000011   Requirement承認フロー      partial       1 (draft)
+
+サマリー: 5 covered, 2 partial, 3 not-covered (合計: 10)
+```
+
+### 3.3 SpecValidationService (`services/spec-validation-service.ts` - 新規)
+
+**責務:** design.mdの静的検証ロジック。
+
+```typescript
+export interface DesignValidation {
+  specId: string;
+  rules: ValidationRuleResult[];
+  passed: number;
+  warnings: number;
+  errors: number;
+  validatedAt: string;
+}
+
+export interface ValidationRuleResult {
+  ruleId: string;
+  ruleName: string;
+  severity: "error" | "warning" | "info";
+  status: "pass" | "fail";
+  message?: string;
+  location?: { line: number; content: string };
+}
+
+export async function validateSpecDesign(
+  cwd: string,
+  specId: string,
+): Promise<DesignValidation>;
+```
+
+**検証ルール一覧:**
+
+| ルールID | 名称 | 検証内容 | 重要度 |
+|---------|------|---------|--------|
+| `arch-layer` | レイヤー整合性 | design.mdに記載されたレイヤー構成がtechnical.mdのパターンに準拠 | error |
+| `arch-dependency` | 依存方向 | 上位レイヤーから下位レイヤーへの一方向依存 | error |
+| `naming-convention` | 命名規則 | コンポーネント名がstructure.mdの命名パターンに準拠 | warning |
+| `dep-conflict` | 依存関係矛盾 | 対象Specificationの要件が依存する他要件のSpecificationが存在すること | warning |
+| `design-sections` | セクション構成 | 必須セクション（設計概要、アーキテクチャ、コンポーネント設計等）の存在チェック | warning |
+| `test-strategy` | テスト方針記載 | テスト方針セクションにユニットテスト/統合テストの記載があること | info |
+
+### 3.4 CoverageService (`services/coverage-service.ts` - 新規)
+
+**責務:** 要件カバレッジの計算。
+
+```typescript
+export type CoverageStatus = "covered" | "partial" | "not-covered";
+
+export interface RequirementCoverage {
+  requirementId: string;
+  title: string;
+  status: CoverageStatus;
+  specifications: Array<{
+    id: string;
+    status: Status;
+  }>;
+}
+
+export interface CoverageReport {
+  requirements: RequirementCoverage[];
+  summary: {
+    covered: number;
+    partial: number;
+    notCovered: number;
+    total: number;
+  };
+  analyzedAt: string;
+}
+
+export async function analyzeRequirementCoverage(
+  cwd: string,
+  requirementId?: string,
+): Promise<CoverageReport>;
+```
+
+**カバレッジ判定ロジック:**
+- `covered`: approved状態のSpecificationが1件以上存在
+- `partial`: draft/pending_approval状態のSpecificationのみ存在
+- `not-covered`: Specificationが0件
+
+### 3.5 SpecificationSchema拡張
+
+**追加フィールド:**
+
+```typescript
+designValidation: z.object({
+  passed: z.number(),
+  warnings: z.number(),
+  errors: z.number(),
+  rules: z.array(z.object({
+    ruleId: z.string(),
+    status: z.enum(["pass", "fail"]),
+    severity: z.enum(["error", "warning", "info"]),
+    message: z.string().optional(),
+  })),
+  validatedAt: z.string(),
+}).optional(),
+```
+
+## 4. データフロー
+
+### 設計検証フロー
+
+```
+ユーザー → reqord spec validate spec-000014
+  → validateCommand.action("spec-000014")
+    → specValidationService.validateSpecDesign(cwd, "spec-000014")
+      → specRepo.findById(cwd, "spec-000014") → Specification取得
+      → specRepo.loadFile(cwd, "spec-000014", "design.md") → 設計文書取得
+      → contextRepo.load(cwd) → ProjectContext取得
+        → technical.md → アーキテクチャパターン抽出
+        → structure.md → 命名規則パターン抽出
+      → 各検証ルールを順次実行:
+        → archLayerRule(design, technicalPatterns)
+        → archDependencyRule(design, technicalPatterns)
+        → namingConventionRule(design, structurePatterns)
+        → depConflictRule(spec, allSpecs, allReqs)
+        → designSectionsRule(design)
+        → testStrategyRule(design)
+      → DesignValidation構築
+    → specRepo.save(cwd, { ...spec, designValidation }) → 結果永続化
+  → 検証結果テーブル表示
+```
+
+### カバレッジ分析フロー
+
+```
+ユーザー → reqord spec coverage
+  → coverageCommand.action()
+    → coverageService.analyzeRequirementCoverage(cwd)
+      → reqRepo.findAll(cwd) → 全要件取得
+      → specRepo.findAll(cwd) → 全仕様取得
+      → 各要件に対して:
+        → requirementIdでSpecificationをフィルタ
+        → カバレッジステータス判定
+      → CoverageReport構築
+  → テーブル表示 + サマリー
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **各検証ルール**: ルールごとにpass/failケースを検証
+  - archLayerRule: 正しいレイヤー構成→pass、不正な依存→fail
+  - namingConventionRule: 規則準拠→pass、規則違反→warning
+  - designSectionsRule: 必須セクション全存在→pass、欠落→fail
+- **カバレッジ計算**: covered/partial/not-coveredの判定ロジック
+- **ProjectContext未設定時**: デフォルトルールでの検証（エラーにならないこと）
+
+### 統合テスト
+
+- Specification作成 → design.md記載 → validate の一連フロー
+- 全要件に対するcoverage分析の実行
+- designValidationフィールドが正しくJSON永続化されること
+- `--json` 出力フォーマット検証
+
+## 6. 技術的決定事項
+
+### ルールベース検証（AIなし）
+
+**決定:** 検証はルールベースの静的チェックのみ（AI/LLMは使用しない）
+**理由:** 検証の再現性と決定論的な結果が重要。AIベースの検証は結果が不安定になり、CI/CDパイプラインでの利用に適さない。将来的にAI支援による高度な検証を追加する場合は別コマンドとして提供する。
+
+### ProjectContextへの依存
+
+**決定:** 検証ルールのパラメータはProjectContext（technical.md, structure.md）から動的に取得
+**理由:** プロジェクトごとに異なるアーキテクチャパターンや命名規則に対応する必要がある。ハードコードではなく、ProjectContextから読み取ることで汎用性を確保。ProjectContext未設定時はデフォルトルール（セクション構成チェック等）のみ実行。
+
+### カバレッジの3段階評価
+
+**決定:** covered / partial / not-covered の3段階で評価
+**理由:** approved状態のSpecificationがある（covered）と、draft段階のSpecificationしかない（partial）では品質保証レベルが異なる。この区別を明確にすることで、プロジェクト全体の仕様策定進捗を正確に把握できる。

--- a/.reqord/specifications/spec-000015.json
+++ b/.reqord/specifications/spec-000015.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000015",
+  "requirementId": "req-000015",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.812Z",
+  "updatedAt": "2026-02-08T14:08:07.812Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000015/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000015/design.md
+++ b/.reqord/specifications/spec-000015/design.md
@@ -1,0 +1,220 @@
+# Specification承認フロー - 技術設計書
+
+## 1. 設計概要
+
+Specificationの承認プロセスをGitHub PRベースで管理する。`reqord spec approve <id>` コマンドにより、承認ブランチ作成・ステータス変更・PR自動生成を実行する。spec-000011（Requirement承認フロー）で導入する共通のapproval-serviceを再利用し、Specification固有の前提条件チェック（関連Requirementがapproved済みであること）を追加する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/spec/approve.ts      (新規)
+                    ↓
+Service Layer:  services/approval-service.ts   (spec-000011で追加 - 共通)
+                services/specification-service.ts (既存拡張)
+                    ↓
+Repository:     repositories/specification.ts  (既存)
+                repositories/requirement.ts    (既存)
+                repositories/git.ts            (spec-000011で追加)
+                repositories/github.ts         (spec-000011で追加)
+                    ↓
+External:       git CLI / gh CLI
+                    ↓
+Storage:        .reqord/specifications/spec-NNNNNN.json
+                GitHub PR
+```
+
+Requirement承認フローと同一のapproval-serviceを使用し、Specification固有のロジック（前提条件チェック、PR本文テンプレート）のみをコマンド層とサービス層で追加する。
+
+## 3. コンポーネント設計
+
+### 3.1 approveコマンド (`commands/spec/approve.ts` - 新規)
+
+**責務:** CLIエントリポイント。承認対象のSpecification ID受け取り。
+
+```
+reqord spec approve <id> [--dry-run]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<id>` | 承認対象のSpecification ID（spec-NNNNNN） |
+| `--dry-run` | 実際のGit/GitHub操作を行わず、実行予定の内容を表示 |
+
+### 3.2 前提条件チェック
+
+Specification承認の前提条件は、Requirement承認より厳格:
+
+1. **Specificationのステータスがdraft**であること
+2. **関連Requirementのステータスがapprovedまたはpending_approval**であること
+   - 未承認の要件に対する仕様承認は整合性に問題がある
+3. **design.mdが空でない（テンプレートのままではない）**こと
+   - 設計文書が実際に記述されている必要がある
+
+```typescript
+async function checkSpecApprovalPrerequisites(
+  cwd: string,
+  specId: string,
+): Promise<{ ok: boolean; errors: string[] }> {
+  const spec = await specRepo.findById(cwd, specId);
+  const errors: string[] = [];
+
+  // 1. ステータスチェック
+  if (spec.status !== "draft") {
+    errors.push(`Specificationのステータスが draft ではありません（現在: ${spec.status}）`);
+  }
+
+  // 2. 関連Requirementのステータスチェック
+  const req = await reqRepo.findById(cwd, spec.requirementId);
+  if (req && req.status !== "approved" && req.status !== "pending_approval") {
+    errors.push(`関連要件 ${spec.requirementId} が未承認です（現在: ${req.status}）`);
+  }
+
+  // 3. design.mdの内容チェック
+  const design = await specRepo.loadFile(cwd, specId, "design.md");
+  if (!design || design.includes("Phase 3で実装予定")) {
+    errors.push("design.mdがテンプレートのままです。設計内容を記述してください。");
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+```
+
+### 3.3 ApprovalServiceの再利用
+
+spec-000011で定義したApprovalTarget/ApprovalServiceをそのまま利用:
+
+```typescript
+const target: ApprovalTarget = {
+  type: "specification",
+  id: spec.id,
+  version: spec.version,
+  status: spec.status,
+  title: `Specification ${spec.id} (${req.title})`,
+  files: [
+    `.reqord/specifications/${spec.id}.json`,
+    `.reqord/specifications/${spec.id}/design.md`,
+  ],
+};
+
+const result = await startApproval(cwd, target, { dryRun: options.dryRun });
+```
+
+### 3.4 ブランチ命名規則
+
+```
+reqord/spec-<id>-approve-v<version>
+例: reqord/spec-000015-approve-v1.0.0
+```
+
+### 3.5 SpecificationSchema拡張
+
+**追加フィールド（spec-000011で定義したcurrentApprovalと同一パターン）:**
+
+```typescript
+currentApproval: z.object({
+  version: z.string(),
+  phase: z.literal("specification"),
+  prNumber: z.number(),
+  prUrl: z.string(),
+  approvedBy: z.array(z.string()),
+  approvedAt: z.string().optional(),
+}).optional(),
+```
+
+### 3.6 PR本文テンプレート
+
+```markdown
+## 仕様承認依頼
+
+| フィールド | 値 |
+|-----------|------|
+| Specification ID | {specId} |
+| Requirement ID | {reqId} |
+| 要件タイトル | {reqTitle} |
+| バージョン | {version} |
+
+### 設計概要
+{designSummary}
+
+### 変更内容
+status: draft → pending_approval
+
+### 設計ファイル
+- `specifications/{specId}/design.md`
+
+> このPRをマージすると、仕様のステータスが `approved` に更新されます。
+```
+
+**designSummary抽出:** design.mdの「設計概要」セクション（## 1. 設計概要 の直下テキスト）を自動抽出してPR本文に含める。
+
+## 4. データフロー
+
+### 承認開始フロー
+
+```
+ユーザー → reqord spec approve spec-000015
+  → specApproveCommand.action("spec-000015")
+    → specRepo.findById(cwd, "spec-000015") → Specification取得
+    → reqRepo.findById(cwd, spec.requirementId) → 関連Requirement取得
+    → checkSpecApprovalPrerequisites(cwd, "spec-000015")
+      → ステータスチェック: draft → OK
+      → Requirement承認チェック: approved → OK
+      → design.md内容チェック: テンプレートでない → OK
+    → ApprovalTarget構築
+    → approvalService.startApproval(cwd, target)
+      → specificationService.updateSpec(cwd, id, { status: "pending_approval" })
+      → gitRepo.createBranch("reqord/spec-000015-approve-v1.0.0")
+      → gitRepo.checkout("reqord/spec-000015-approve-v1.0.0")
+      → gitRepo.add([".reqord/specifications/spec-000015.json", ".reqord/specifications/spec-000015/design.md"])
+      → gitRepo.commit("chore(reqord): request approval for spec-000015")
+      → gitRepo.push("reqord/spec-000015-approve-v1.0.0")
+      → githubRepo.createPullRequest({ title, body, head })
+    → 成功メッセージ表示（PR URL含む）
+```
+
+### エラーケース: Requirement未承認
+
+```
+ユーザー → reqord spec approve spec-000015
+  → checkSpecApprovalPrerequisites(cwd, "spec-000015")
+    → Requirement承認チェック: req-000015 status=draft → NG
+  → stderr: "エラー: 関連要件 req-000015 が未承認です（現在: draft）"
+  → stderr: "先に 'reqord req approve req-000015' を実行してください。"
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **前提条件チェック**:
+  - Specificationがdraftのときに成功すること
+  - Specificationがdraft以外のときにエラーメッセージが返ること
+  - 関連Requirementがapproved/pending_approvalのときに成功すること
+  - 関連Requirementがdraftのときにエラーメッセージが返ること
+  - design.mdがテンプレートのままのときにエラーメッセージが返ること
+- **ApprovalTarget構築**: type="specification"、files配列にdesign.mdが含まれること
+- **designSummary抽出**: 設計概要セクションの正しい抽出
+- **ブランチ名生成**: "reqord/spec-{id}-approve-v{version}" 形式
+
+### 統合テスト
+
+- Requirement承認済み → Specification承認の一連フロー
+- `--dry-run` モードでの動作確認
+- 前提条件エラー時の適切なメッセージ表示
+
+## 6. 技術的決定事項
+
+### 共通approval-serviceの再利用
+
+**決定:** spec-000011で作成するapproval-serviceをそのまま利用し、Specification固有ロジックはコマンド層に実装
+**理由:** 承認フローの核心（ブランチ作成→コミット→プッシュ→PR作成）は同一。ApprovalTargetインターフェースにより、RequirementとSpecificationの差異を吸収できる。重複コードを排除しつつ、各承認対象の固有ロジック（前提条件チェック、PR本文テンプレート）は分離可能。
+
+### Requirement承認の前提条件化
+
+**決定:** Specification承認時に関連Requirementのapproved/pending_approvalステータスを前提条件とする
+**理由:** 未承認の要件に対して仕様を承認しても、要件自体が変更される可能性がある。要件→仕様の承認順序を強制することで、手戻りリスクを最小化する。pending_approvalも許容するのは、要件承認と仕様承認を並行して進められるようにするため。
+
+### design.mdの空チェック
+
+**決定:** テンプレートのままのdesign.mdでは承認を拒否
+**理由:** 設計文書が実際に記述されていない仕様の承認は意味がない。テンプレートのデフォルトテキスト（「Phase 3で実装予定」等）が残っている場合はエラーとする。

--- a/.reqord/specifications/spec-000016.json
+++ b/.reqord/specifications/spec-000016.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000016",
+  "requirementId": "req-000016",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.899Z",
+  "updatedAt": "2026-02-08T14:08:07.899Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000016/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000016/design.md
+++ b/.reqord/specifications/spec-000016/design.md
@@ -1,0 +1,345 @@
+# GitHub Issue生成 - 技術設計書
+
+## 1. 設計概要
+
+SpecificationからGitHub Issueを自動生成する機能を提供する。Anthropic SDK（Claude API）を使用してSpecificationのdesign.mdを解析し、実装タスクに分解する。分解戦略（by-layer, by-feature, by-requirement, custom）を選択可能にし、並列グループ（P0/P1/P2）とクリティカルパスを自動計算する。GitHub Issue Templateの適用、ラベル自動付与、`--dry-run`によるプレビューをサポートする。本specでは分解とIssue作成（書き込み操作）を扱い、Issue同期・追跡（spec-000024）は対象外とする。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/issue/create.ts      (新規)
+                    ↓
+Service Layer:  services/issue-service.ts      (新規)
+                services/decomposition-service.ts (新規 - AI分解)
+                    ↓
+Repository:     repositories/specification.ts  (既存)
+                repositories/requirement.ts    (既存)
+                repositories/github.ts         (spec-000011で追加)
+                repositories/ai.ts             (新規 - Anthropic SDK)
+                    ↓
+External:       Anthropic API (Claude)
+                gh CLI (Issue作成)
+                    ↓
+Storage:        .reqord/specifications/spec-NNNNNN.json (implementationフィールド)
+                .reqord/issue-templates/                (テンプレート)
+                GitHub Issues
+```
+
+AI分解ロジックはdecomposition-serviceに隔離し、issue-serviceはGitHub Issue作成の調整役として機能する。AI APIへのアクセスはリポジトリ層（ai.ts）に抽象化し、テスト時のモック化を容易にする。
+
+## 3. コンポーネント設計
+
+### 3.1 createコマンド (`commands/issue/create.ts` - 新規)
+
+**責務:** Issue生成の実行と結果表示。
+
+```
+reqord issue create <spec-id> [options]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<spec-id>` | 対象のSpecification ID |
+| `--strategy <type>` | 分解戦略: by-layer, by-feature, by-requirement, custom（デフォルト: by-layer） |
+| `--dry-run` | Issue作成をせず分解結果のみ表示 |
+| `--json` | 構造化JSON出力 |
+| `--max-issues <n>` | 生成Issue最大数（デフォルト: 20） |
+| `--no-ai` | AI分解を使用せず、手動分解テンプレートを表示 |
+
+### 3.2 DecompositionService (`services/decomposition-service.ts` - 新規)
+
+**責務:** SpecificationのAI分解ロジック。
+
+```typescript
+export type DecompositionStrategy = "by-layer" | "by-feature" | "by-requirement" | "custom";
+
+export interface DecomposedTask {
+  title: string;
+  description: string;
+  priority: "P0" | "P1" | "P2";
+  estimatedHours: number;
+  dependencies: string[];  // 他タスクへの参照（タイトルベース）
+  labels: string[];
+  layer?: string;           // by-layer時: "command", "service", "repository", "shared"
+  feature?: string;         // by-feature時: 機能グループ名
+}
+
+export interface DecompositionResult {
+  specId: string;
+  strategy: DecompositionStrategy;
+  tasks: DecomposedTask[];
+  parallelGroups: ParallelGroup[];
+  criticalPath: string[];
+  totalEstimatedHours: number;
+}
+
+export interface ParallelGroup {
+  priority: "P0" | "P1" | "P2";
+  tasks: DecomposedTask[];
+  description: string;
+}
+
+export async function decomposeSpecification(
+  cwd: string,
+  specId: string,
+  strategy: DecompositionStrategy,
+  options?: { maxTasks?: number },
+): Promise<DecompositionResult>;
+```
+
+### 3.3 分解戦略
+
+**by-layer（デフォルト）:**
+アーキテクチャレイヤーごとにタスクを分解。
+```
+P0: Shared（スキーマ定義、型定義）
+P1: Repository（データアクセス層）
+P1: Service（ビジネスロジック）
+P2: Command（CLIインターフェース）
+P2: Test（テストコード）
+```
+
+**by-feature:**
+機能単位でタスクを分解。各機能内にレイヤーを包含。
+```
+P0: コア機能A（Schema + Service + Command）
+P1: 補助機能B（Schema + Service + Command）
+P2: オプション機能C
+```
+
+**by-requirement:**
+成功基準ごとにタスクを分解。各基準を実現するための実装タスクを生成。
+
+**custom:**
+AIに自由に分解させる（プロンプトでガイダンスのみ提供）。
+
+### 3.4 AIRepository (`repositories/ai.ts` - 新規)
+
+**責務:** Anthropic SDKのラッパー。
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+export interface AICompletionOptions {
+  model?: string;         // デフォルト: "claude-sonnet-4-20250514"
+  maxTokens?: number;
+  systemPrompt?: string;
+}
+
+export async function complete(
+  userPrompt: string,
+  options?: AICompletionOptions,
+): Promise<string>;
+
+export async function completeWithSchema<T>(
+  userPrompt: string,
+  schema: z.ZodSchema<T>,
+  options?: AICompletionOptions,
+): Promise<T>;
+```
+
+APIキーは環境変数 `ANTHROPIC_API_KEY` から取得。未設定時はAppError(MISSING_API_KEY)をスロー。
+
+### 3.5 IssueService (`services/issue-service.ts` - 新規)
+
+**責務:** 分解結果からGitHub Issueを作成。
+
+```typescript
+export interface CreateIssuesOptions {
+  specId: string;
+  strategy: DecompositionStrategy;
+  dryRun?: boolean;
+  maxIssues?: number;
+}
+
+export interface CreateIssuesResult {
+  specId: string;
+  issues: CreatedIssue[];
+  parallelGroups: ParallelGroup[];
+  criticalPath: string[];
+}
+
+export interface CreatedIssue {
+  title: string;
+  number?: number;      // dry-run時はundefined
+  url?: string;         // dry-run時はundefined
+  priority: string;
+  labels: string[];
+}
+
+export async function createIssuesFromSpec(
+  cwd: string,
+  options: CreateIssuesOptions,
+): Promise<CreateIssuesResult>;
+```
+
+### 3.6 GitHub Issue Template適用
+
+Issue作成時に `.reqord/issue-templates/reqord-implementation.yml` または `.github/ISSUE_TEMPLATE/reqord-implementation.yml` のテンプレートを適用する。
+
+**テンプレート構造:**
+```yaml
+name: reqord実装タスク
+description: reqordから自動生成された実装タスク
+labels: ["reqord-generated"]
+body:
+  - type: markdown
+    attributes:
+      value: "## タスク概要"
+  - type: textarea
+    id: description
+    attributes:
+      label: 説明
+  - type: input
+    id: spec-id
+    attributes:
+      label: Specification ID
+  - type: input
+    id: priority
+    attributes:
+      label: 優先度
+```
+
+### 3.7 ラベル自動付与
+
+各Issueに以下のラベルを自動付与:
+- `reqord-generated`: reqordから生成されたIssue
+- `spec:<spec-id>`: 対象Specification（例: `spec:spec-000016`）
+- `req:<req-id>`: 関連Requirement（例: `req:req-000016`）
+- `P<n>`: 優先度（例: `P0`, `P1`, `P2`）
+
+### 3.8 SpecificationSchema拡張
+
+**追加フィールド:**
+
+```typescript
+implementation: z.object({
+  issues: z.array(z.object({
+    number: z.number(),
+    title: z.string(),
+    url: z.string(),
+    priority: z.string(),
+    status: z.enum(["open", "in_progress", "closed"]).default("open"),
+  })),
+  strategy: z.string(),
+  totalEstimatedHours: z.number(),
+  createdAt: z.string(),
+}).optional(),
+```
+
+### 3.9 クリティカルパス計算
+
+タスク間の依存関係（dependencies）に基づいてクリティカルパスを計算:
+
+```typescript
+function calculateCriticalPath(tasks: DecomposedTask[]): string[] {
+  // トポロジカルソート + 最長パス計算
+  // 各タスクのestimatedHoursを重みとして使用
+  // 最長パスのタスクタイトル配列を返す
+}
+```
+
+## 4. データフロー
+
+### Issue生成フロー
+
+```
+ユーザー → reqord issue create spec-000016 --strategy by-layer
+  → createCommand.action("spec-000016", { strategy: "by-layer" })
+    → issueService.createIssuesFromSpec(cwd, options)
+      → specRepo.findById(cwd, "spec-000016") → Specification取得
+      → specRepo.loadFile(cwd, "spec-000016", "design.md") → 設計文書取得
+      → reqRepo.findById(cwd, spec.requirementId) → 関連Requirement取得
+      → decompositionService.decomposeSpecification(cwd, "spec-000016", "by-layer")
+        → aiRepo.completeWithSchema(prompt, DecompositionResultSchema)
+          → Anthropic API呼び出し
+          → レスポンスをZodスキーマでパース
+        → 並列グループ計算
+        → クリティカルパス計算
+        → DecompositionResult返却
+      → Issue Template読み込み
+      → 各タスクに対して:
+        → ラベル生成: ["reqord-generated", "spec:spec-000016", "req:req-000016", "P0"]
+        → Issue本文生成（テンプレート適用）
+        → githubRepo.createIssue({ title, body, labels })
+          → gh issue create --title "..." --body "..." --label "..."
+      → Specification JSONにimplementationフィールド記録
+    → CreateIssuesResult返却
+  → テーブル表示:
+    | # | タイトル | 優先度 | Issue# | URL |
+    | 1 | スキーマ定義 | P0 | #42 | https://... |
+```
+
+### dry-runフロー
+
+```
+ユーザー → reqord issue create spec-000016 --dry-run
+  → decompositionService.decomposeSpecification(...) → 分解実行
+  → GitHub Issueは作成しない
+  → 分解結果をテーブル表示:
+    | # | タイトル | 優先度 | 見積もり | 依存 |
+    | 1 | スキーマ定義 | P0 | 2h | なし |
+    | 2 | Repository実装 | P1 | 4h | 1 |
+  →
+  → 並列グループ表示:
+    P0: スキーマ定義
+    P1: Repository実装, Service実装（並列可）
+    P2: Command実装, テスト
+  →
+  → クリティカルパス: スキーマ定義 → Repository実装 → Service実装 → Command実装
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **decomposition-service**:
+  - 各分解戦略のプロンプト生成（by-layer, by-feature, by-requirement, custom）
+  - AIレスポンスのZodパース（正常系・不正レスポンス時のエラー）
+  - 並列グループ計算: P0/P1/P2への正しい分類
+  - クリティカルパス計算: 線形依存、分岐依存、独立タスク
+- **issue-service**:
+  - ラベル生成ロジック
+  - Issue本文テンプレート適用
+  - dry-runモード: GitHub API呼び出しなし
+  - maxIssues制限の動作
+- **ai repository**:
+  - APIキー未設定時のエラー
+  - Zodスキーマでのレスポンスパース
+
+### 統合テスト
+
+- Specification作成 → issue create --dry-run の一連フロー（API呼び出しなし）
+- implementationフィールドのJSON永続化
+- `--json` 出力フォーマット検証
+
+### AIレスポンスのモックテスト
+
+AIリポジトリをモック化し、事前定義されたレスポンスで分解ロジックを検証。実際のAPI呼び出しはテストから除外する。
+
+## 6. 技術的決定事項
+
+### Anthropic SDK（Claude API）の採用
+
+**決定:** タスク分解にAnthropic SDK（Claude API）を使用
+**理由:** Specificationの設計文書（自然言語）を解析して構造化されたタスクに分解するには、LLMの自然言語理解能力が必要。reqordプロジェクトの主要AIとしてClaudeを採用しており、SDKの型安全性とストリーミングサポートが利用可能。
+
+### 分解結果のZodスキーマ検証
+
+**決定:** AIレスポンスをZodスキーマで検証し、型安全なDecompositionResultとして返す
+**理由:** AIの出力は非決定論的であり、期待するフォーマットに準拠していない可能性がある。Zodスキーマによる検証でランタイムエラーを防ぎ、不正なレスポンス時はリトライまたはエラーメッセージを表示する。
+
+### dry-runモードの必須サポート
+
+**決定:** `--dry-run` オプションを必須サポート
+**理由:** AI分解結果は予測困難であり、意図しないIssue大量生成のリスクがある。Human-in-the-loopの原則に基づき、生成前にプレビューを確認できる仕組みが必須。
+
+### Issue同期の分離（spec-000024）
+
+**決定:** Issue作成（本spec）とIssue同期・追跡（spec-000024）を分離
+**理由:** 作成は一方向の書き込み操作であり、同期は双方向の状態管理が必要。責務を分離することで、それぞれの複雑さを独立して管理可能にする。
+
+### APIキーの環境変数管理
+
+**決定:** Anthropic APIキーは環境変数 `ANTHROPIC_API_KEY` から取得
+**理由:** APIキーをファイルに保存するとGitにコミットされるリスクがある。環境変数による管理はセキュリティのベストプラクティス。未設定時は明確なエラーメッセージを表示する。

--- a/.reqord/specifications/spec-000017.json
+++ b/.reqord/specifications/spec-000017.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000017",
+  "requirementId": "req-000017",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:07.981Z",
+  "updatedAt": "2026-02-08T14:08:07.981Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000017/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000017/design.md
+++ b/.reqord/specifications/spec-000017/design.md
@@ -1,0 +1,339 @@
+# Gap Analysis (既存コード差分分析) - 技術設計書
+
+## 1. 設計概要
+
+新しい要件が既存コードベースとどの程度ギャップがあるかをAI（Anthropic SDK）で分析する。`reqord req gap-analysis <id>` コマンドにより、既存実装のカバレッジ（full/partial/none）、不足機能、既存コードとの矛盾をファイル名・行番号付きで出力する。分析結果はRequirement JSONのgapAnalysisフィールドに記録し、`reqord validate gap <id>` で既存分析の再検証を行う。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/req/gap-analysis.ts   (新規)
+                commands/validate/gap.ts        (新規)
+                    ↓
+Service Layer:  services/gap-analysis-service.ts (新規)
+                    ↓
+Repository:     repositories/requirement.ts     (既存)
+                repositories/ai.ts              (spec-000016で追加)
+                repositories/codebase.ts        (新規 - コードベース走査)
+                    ↓
+External:       Anthropic API (Claude)
+                ファイルシステム (プロジェクトコード)
+                    ↓
+Storage:        .reqord/requirements/req-NNNNNN.json (gapAnalysisフィールド)
+```
+
+コードベースの走査を専用リポジトリ（codebase.ts）に隔離し、AI分析はspec-000016で導入するAIリポジトリを再利用する。分析対象のファイル収集とAI解析を分離することで、テスト性と拡張性を確保する。
+
+## 3. コンポーネント設計
+
+### 3.1 gap-analysisコマンド (`commands/req/gap-analysis.ts` - 新規)
+
+**責務:** Gap Analysisの実行と結果表示。
+
+```
+reqord req gap-analysis <id> [options]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<id>` | 分析対象の要件ID（req-NNNNNN） |
+| `--json` | 構造化JSON出力 |
+| `--path <dir>` | 走査対象ディレクトリ（デフォルト: cwd） |
+| `--include <glob>` | 走査対象パターン（デフォルト: `**/*.ts`） |
+| `--exclude <glob>` | 除外パターン（デフォルト: `node_modules,dist,.reqord`） |
+
+**表示形式:**
+```
+Gap Analysis: req-000010 (Zodバリデーションエラー詳細表示)
+
+既存実装カバレッジ: partial
+
+既存実装:
+  [FULL]    packages/shared/src/schemas/validation.ts
+            → バリデーション結果スキーマが定義済み
+  [PARTIAL] packages/cli/src/repositories/requirement.ts
+            → safeParse使用だがエラーフォーマット未実装
+
+不足機能:
+  1. ZodError.issuesの日本語フォーマッタ
+  2. フィールドパスのドット表記変換
+  3. 全エラー同時表示ロジック
+
+矛盾:
+  [CONFLICT] packages/cli/src/services/requirement-service.ts:162
+             → 現在: error.message（Zodデフォルト形式）
+             → 要件: フィールドパス+期待値の日本語フォーマット
+```
+
+### 3.2 validate gapコマンド (`commands/validate/gap.ts` - 新規)
+
+**責務:** 既存Gap Analysis結果の再検証。
+
+```
+reqord validate gap <id> [--json]
+```
+
+前回の分析結果が記録されている場合、現在のコードベースに対して再検証を行い、解消されたギャップ・新たに発生したギャップを特定する。
+
+### 3.3 GapAnalysisService (`services/gap-analysis-service.ts` - 新規)
+
+**責務:** Gap Analysis のオーケストレーション。
+
+```typescript
+export interface GapAnalysis {
+  requirementId: string;
+  coverage: "full" | "partial" | "none";
+  existingImplementations: ExistingImplementation[];
+  missingFeatures: MissingFeature[];
+  conflicts: Conflict[];
+  analyzedAt: string;
+  codebaseSnapshot: {
+    totalFiles: number;
+    analyzedFiles: number;
+    path: string;
+  };
+}
+
+export interface ExistingImplementation {
+  filePath: string;
+  coverage: "full" | "partial";
+  description: string;
+  relevantLines?: { start: number; end: number };
+}
+
+export interface MissingFeature {
+  description: string;
+  priority: "high" | "medium" | "low";
+  suggestedLocation?: string;  // 実装推奨ファイルパス
+}
+
+export interface Conflict {
+  filePath: string;
+  line: number;
+  currentBehavior: string;
+  requiredBehavior: string;
+  severity: "breaking" | "incompatible" | "style";
+}
+
+export async function analyzeGap(
+  cwd: string,
+  requirementId: string,
+  options?: GapAnalysisOptions,
+): Promise<GapAnalysis>;
+
+export async function revalidateGap(
+  cwd: string,
+  requirementId: string,
+): Promise<GapRevalidationResult>;
+```
+
+### 3.4 CodebaseRepository (`repositories/codebase.ts` - 新規)
+
+**責務:** プロジェクトコードベースの走査と要約。
+
+```typescript
+export interface CodebaseFile {
+  path: string;
+  content: string;
+  lines: number;
+}
+
+export interface CodebaseSummary {
+  files: CodebaseFile[];
+  totalFiles: number;
+  totalLines: number;
+}
+
+export interface ScanOptions {
+  basePath: string;
+  include?: string[];    // globパターン
+  exclude?: string[];    // globパターン
+  maxFileSize?: number;  // バイト（デフォルト: 50KB）
+  maxFiles?: number;     // 最大ファイル数（デフォルト: 100）
+}
+
+export async function scanCodebase(options: ScanOptions): Promise<CodebaseSummary>;
+export async function readFileWithLineNumbers(filePath: string): Promise<string>;
+```
+
+**走査戦略:**
+1. globパターンでファイル一覧を取得
+2. maxFileSize/maxFiles制限を適用
+3. 各ファイルの内容を読み込み
+4. ファイルサイズの大きなファイルは先頭部分のみ（トークン節約）
+
+### 3.5 AI分析プロンプト設計
+
+**System Prompt:**
+```
+あなたはソフトウェアエンジニアのアシスタントです。
+与えられた要件とコードベースを分析し、以下を特定してください:
+1. 要件に関連する既存実装（ファイルパス、カバレッジ）
+2. 不足している機能
+3. 既存コードと要件の間の矛盾（ファイル名、行番号を含む）
+
+出力は指定されたJSONスキーマに従ってください。
+```
+
+**User Prompt構築:**
+```
+## 要件
+ID: {id}
+タイトル: {title}
+成功基準:
+{successCriteria}
+
+説明:
+{description}
+
+## コードベース
+{files}
+
+## 分析してください
+```
+
+コードベースのファイル数が多い場合は、段階的な分析を行う:
+1. **Phase 1（候補絞り込み）:** ファイルパスと先頭コメント/export一覧のみをAIに渡し、関連ファイルを特定
+2. **Phase 2（詳細分析）:** Phase 1で特定されたファイルの全文をAIに渡し、詳細分析
+
+### 3.6 RequirementSchema拡張
+
+**追加フィールド:**
+
+```typescript
+gapAnalysis: z.object({
+  coverage: z.enum(["full", "partial", "none"]),
+  existingImplementations: z.array(z.object({
+    filePath: z.string(),
+    coverage: z.enum(["full", "partial"]),
+    description: z.string(),
+  })),
+  missingFeatures: z.array(z.object({
+    description: z.string(),
+    priority: z.enum(["high", "medium", "low"]),
+  })),
+  conflicts: z.array(z.object({
+    filePath: z.string(),
+    line: z.number(),
+    currentBehavior: z.string(),
+    requiredBehavior: z.string(),
+    severity: z.enum(["breaking", "incompatible", "style"]),
+  })),
+  analyzedAt: z.string(),
+}).optional(),
+```
+
+### 3.7 再検証ロジック
+
+```typescript
+export interface GapRevalidationResult {
+  requirementId: string;
+  previousAnalysis: GapAnalysis;
+  currentAnalysis: GapAnalysis;
+  resolvedGaps: string[];       // 解消されたギャップ
+  newGaps: string[];            // 新たに発生したギャップ
+  unchangedGaps: string[];      // 未解消のギャップ
+  coverageChange: {
+    before: "full" | "partial" | "none";
+    after: "full" | "partial" | "none";
+  };
+}
+```
+
+## 4. データフロー
+
+### Gap Analysis実行フロー
+
+```
+ユーザー → reqord req gap-analysis req-000010
+  → gapAnalysisCommand.action("req-000010")
+    → gapAnalysisService.analyzeGap(cwd, "req-000010")
+      → reqRepo.findById(cwd, "req-000010") → Requirement取得
+      → reqRepo.loadDescription(cwd, "req-000010") → 説明文取得
+      → codebaseRepo.scanCodebase({ basePath: cwd, include: ["**/*.ts"], ... })
+        → ファイル一覧取得 → 制限適用 → ファイル内容読み込み
+      → Phase 1: 候補絞り込み
+        → aiRepo.completeWithSchema(summaryPrompt, CandidateSchema)
+        → 関連ファイル5-10件を特定
+      → Phase 2: 詳細分析
+        → aiRepo.completeWithSchema(detailPrompt, GapAnalysisSchema)
+        → GapAnalysis構築
+      → reqRepo.save(cwd, { ...requirement, gapAnalysis })
+    → GapAnalysis返却
+  → 結果表示（テーブル / JSON）
+```
+
+### 再検証フロー
+
+```
+ユーザー → reqord validate gap req-000010
+  → validateGapCommand.action("req-000010")
+    → gapAnalysisService.revalidateGap(cwd, "req-000010")
+      → reqRepo.findById(cwd, "req-000010") → 既存gapAnalysis取得
+      → analyzeGap(cwd, "req-000010") → 最新分析実行
+      → 前回結果との差分比較
+        → resolvedGaps: 前回あったが今回なくなったギャップ
+        → newGaps: 前回なかったが今回発生したギャップ
+      → GapRevalidationResult返却
+  → 差分表示:
+    解消: 2件
+    新規: 0件
+    未解消: 1件
+    カバレッジ: partial → partial
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **gap-analysis-service**:
+  - 正常系: full/partial/noneの各カバレッジ判定
+  - Conflict検出: ファイルパス・行番号の正確性
+  - MissingFeature: priority判定ロジック
+  - 前回結果との差分比較（revalidateGap）
+- **codebase repository**:
+  - globパターンによるファイルフィルタリング
+  - maxFileSize制限: 大きなファイルの切り詰め
+  - maxFiles制限: ファイル数上限
+  - 除外パターン（node_modules, dist等）の動作
+- **AI分析プロンプト**:
+  - プロンプト構築ロジック（要件情報 + コードベース情報の結合）
+  - Phase 1/Phase 2の段階的分析フロー
+
+### 統合テスト
+
+- テスト用の小規模コードベースでの分析実行（AIモック使用）
+- gapAnalysisフィールドのJSON永続化
+- `--json` 出力フォーマット検証
+- `--path`, `--include`, `--exclude` オプションの動作
+
+### AIモックテスト
+
+AIリポジトリをモック化し、事前定義されたレスポンスで分析ロジックを検証。Phase 1 → Phase 2の段階的呼び出しが正しく行われることを確認。
+
+## 6. 技術的決定事項
+
+### 段階的分析（Phase 1 + Phase 2）
+
+**決定:** コードベースの走査を2段階に分けて実行
+**理由:** 大規模プロジェクトでは全ファイルをAIに渡すとトークン制限に達する。Phase 1でファイル名ベースの絞り込みを行い、Phase 2で関連ファイルのみを詳細分析することで、精度とコストのバランスを取る。
+
+### コードベースリポジトリの分離
+
+**決定:** プロジェクトコードの走査を専用リポジトリ（codebase.ts）に隔離
+**理由:** `.reqord/` 内のファイル管理（requirement.ts, specification.ts）とプロジェクト本体のコード走査は異なる責務。テスト時にコードベース走査をモック化でき、ファイルシステムアクセスのパフォーマンス最適化（キャッシュ等）も独立して行える。
+
+### ファイルサイズ制限
+
+**決定:** 走査対象ファイルにサイズ上限（50KB）を設定し、超過分は先頭部分のみ取得
+**理由:** 大きなファイル（生成コード、バンドルファイル等）はAIトークンを大量に消費し、分析品質に寄与しない。先頭部分にexport/import宣言が含まれるため、ファイルの役割理解には十分。
+
+### 再検証機能の提供
+
+**決定:** `reqord validate gap` による既存分析の再検証をサポート
+**理由:** Gap Analysisは実装の進行とともに結果が変化する。コード変更後に再検証することで、ギャップの解消状況を追跡可能にする。前回結果との差分表示により、進捗を可視化。
+
+### AIレスポンスのZodスキーマ検証
+
+**決定:** spec-000016と同様に、AIレスポンスをZodスキーマで検証
+**理由:** AIの出力に対する型安全性を担保する。不正なレスポンス時はリトライまたは部分的な結果として返却し、ユーザーに分析の限界を明示する。

--- a/.reqord/specifications/spec-000018.json
+++ b/.reqord/specifications/spec-000018.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000018",
+  "requirementId": "req-000018",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:08.067Z",
+  "updatedAt": "2026-02-08T14:08:08.067Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000018/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000018/design.md
+++ b/.reqord/specifications/spec-000018/design.md
@@ -1,0 +1,259 @@
+# 実装検証コマンド - 技術設計書
+
+## 1. 設計概要
+
+`reqord validate impl <spec-id>` コマンドにより、Specificationの実装完了度を3つの観点で検証する。(1) GitHub Issueの完了状態、(2) design.mdから抽出したコンポーネントの実装ファイル存在確認、(3) テストファイルの存在確認。design.mdのコンポーネント設計セクションとテスト方針セクションをパースしてファイルパスを抽出し、ファイルシステムの実在性とGitHub Issueの状態をチェックする。`--json` オプションでCI/CD連携、`--strict` オプションで未完了時にexit code 1を返すCIモードを提供する。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/validate/impl.ts        (新規)
+                    ↓
+Service Layer:  services/impl-validation-service.ts (新規)
+                    ↓
+Repository:     repositories/specification.ts     (既存)
+                repositories/requirement.ts       (既存)
+                repositories/github.ts            (spec-000011で追加)
+                repositories/file-system.ts       (既存)
+                    ↓
+External:       gh CLI (Issue状態取得)
+                ファイルシステム (コンポーネント/テスト存在確認)
+                    ↓
+Storage:        .reqord/specifications/spec-NNNNNN.json
+                .reqord/specifications/spec-NNNNNN/design.md
+```
+
+design.mdのパースはサービス層に配置し、GitHub Issue状態取得はspec-000011で導入するgithubリポジトリを再利用する。コンポーネントパス抽出とファイル存在確認を分離することで、テスト時のモック化を容易にする。
+
+## 3. コンポーネント設計
+
+### 3.1 implコマンド (`commands/validate/impl.ts` - 新規)
+
+**責務:** 実装検証の実行と結果表示。
+
+```
+reqord validate impl <spec-id> [options]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<spec-id>` | 検証対象のSpecification ID（spec-NNNNNN） |
+| `--json` | 構造化JSON出力 |
+| `--strict` | 未完了項目がある場合にexit code 1を返す（CI用） |
+
+**表示形式:**
+```
+実装検証: spec-000016 (GitHub Issue生成)
+
+GitHub Issues:
+  [DONE]    #42 スキーマ定義 (P0)
+  [DONE]    #43 Repository実装 (P1)
+  [OPEN]    #44 Service実装 (P1)
+  [OPEN]    #45 Command実装 (P2)
+
+コンポーネント:
+  [EXISTS]  packages/cli/src/commands/issue/create.ts
+  [EXISTS]  packages/cli/src/services/issue-service.ts
+  [MISSING] packages/cli/src/services/decomposition-service.ts
+  [EXISTS]  packages/cli/src/repositories/ai.ts
+
+テストファイル:
+  [EXISTS]  packages/cli/src/services/issue-service.test.ts
+  [MISSING] packages/cli/src/services/decomposition-service.test.ts
+
+サマリー: Issues 2/4, Components 3/4, Tests 1/2
+```
+
+### 3.2 ImplValidationService (`services/impl-validation-service.ts` - 新規)
+
+**責務:** 実装検証のオーケストレーション。
+
+```typescript
+export interface ImplValidation {
+  specId: string;
+  requirementId: string;
+  issueCheck: IssueCheckResult;
+  componentCheck: ComponentCheckResult;
+  testCheck: TestCheckResult;
+  overallStatus: "complete" | "partial" | "not-started";
+  validatedAt: string;
+}
+
+export interface IssueCheckResult {
+  total: number;
+  completed: number;
+  issues: Array<{
+    number: number;
+    title: string;
+    state: "open" | "closed";
+    priority?: string;
+  }>;
+}
+
+export interface ComponentCheckResult {
+  total: number;
+  exists: number;
+  components: Array<{
+    path: string;
+    exists: boolean;
+    description?: string;
+  }>;
+}
+
+export interface TestCheckResult {
+  total: number;
+  exists: number;
+  tests: Array<{
+    path: string;
+    exists: boolean;
+    type: "unit" | "integration";
+  }>;
+}
+
+export async function validateImplementation(
+  cwd: string,
+  specId: string,
+): Promise<ImplValidation>;
+```
+
+### 3.3 Design.mdパーサー
+
+**責務:** design.mdのセクションからコンポーネントパスとテストパスを抽出。
+
+```typescript
+export interface DesignPaths {
+  components: Array<{ path: string; description: string }>;
+  tests: Array<{ path: string; type: "unit" | "integration" }>;
+}
+
+export function parseDesignPaths(designContent: string): DesignPaths;
+```
+
+**パース戦略:**
+
+1. **コンポーネント抽出:** 「コンポーネント設計」セクション（`## 3.`）内のコードブロックやバッククォート内のファイルパスパターン（`packages/`, `src/`で始まる文字列、`.ts`/`.tsx`で終わる文字列）を正規表現で抽出
+2. **セクション見出しからのパス推定:** `### 3.N タイトル (`パス`)` 形式の見出しからパス抽出
+3. **テスト抽出:** 「テスト方針」セクション（`## 5.`）内のファイルパスパターン抽出、および抽出されたコンポーネントパスから `.test.ts` 対応ファイルを推定
+
+**パターンマッチング:**
+```typescript
+// 見出しからのパス抽出
+// 例: ### 3.1 initサービス (`services/init-service.ts`)
+const headingPathPattern = /###\s+\d+\.\d+\s+.+?\(`([^`]+\.tsx?)`\)/g;
+
+// バッククォート内のパス抽出
+// 例: `packages/cli/src/services/issue-service.ts`
+const inlinePathPattern = /`((?:packages\/|src\/)[^`]+\.tsx?)`/g;
+
+// アーキテクチャ図からのパス抽出
+// 例: services/issue-service.ts      (新規)
+const archPathPattern = /^\s+([\w\-./]+\.tsx?)\s/gm;
+```
+
+### 3.4 GitHub Issue状態チェック
+
+**責務:** Specification JSONのimplementationフィールドに記録されたIssue番号のGitHub状態を取得。
+
+```typescript
+async function checkIssueStates(
+  issues: Array<{ number: number; title: string }>,
+): Promise<IssueCheckResult> {
+  // gh issue view <number> --json state で各Issueの状態を取得
+  // implementationフィールドがない場合は空の結果を返す
+}
+```
+
+spec-000016で定義されるSpecificationのimplementationフィールドを参照する。implementationフィールドが存在しない場合、Issueチェックはスキップされ、コンポーネント・テストチェックのみ実行される。
+
+### 3.5 overallStatus判定ロジック
+
+```typescript
+function determineOverallStatus(
+  issueCheck: IssueCheckResult,
+  componentCheck: ComponentCheckResult,
+  testCheck: TestCheckResult,
+): "complete" | "partial" | "not-started" {
+  const issueComplete = issueCheck.total === 0 || issueCheck.completed === issueCheck.total;
+  const componentComplete = componentCheck.exists === componentCheck.total;
+  const testComplete = testCheck.exists === testCheck.total;
+
+  if (issueComplete && componentComplete && testComplete) return "complete";
+  if (componentCheck.exists === 0 && testCheck.exists === 0) return "not-started";
+  return "partial";
+}
+```
+
+## 4. データフロー
+
+### 実装検証フロー
+
+```
+ユーザー → reqord validate impl spec-000016
+  → implValidateCommand.action("spec-000016")
+    → implValidationService.validateImplementation(cwd, "spec-000016")
+      → specRepo.findById(cwd, "spec-000016") → Specification取得
+      → specRepo.loadFile(cwd, "spec-000016", "design.md") → 設計文書取得
+      → reqRepo.findById(cwd, spec.requirementId) → 関連Requirement取得
+      → parseDesignPaths(designContent)
+        → components: [{path: "commands/issue/create.ts", ...}, ...]
+        → tests: [{path: "services/issue-service.test.ts", ...}, ...]
+      → Issue状態チェック（implementationフィールドが存在する場合）:
+        → spec.implementation.issues.map(i => githubRepo.getIssueState(i.number))
+      → コンポーネント存在チェック:
+        → components.map(c => fs.exists(joinPath(cwd, c.path)))
+      → テスト存在チェック:
+        → tests.map(t => fs.exists(joinPath(cwd, t.path)))
+      → ImplValidation構築
+  → テーブル表示 or JSON出力
+```
+
+### strictモード
+
+```
+ユーザー → reqord validate impl spec-000016 --strict
+  → validateImplementation(cwd, "spec-000016")
+    → overallStatus: "partial"
+  → process.exitCode = 1
+  → stderr: "実装検証失敗: 未完了項目があります"
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **parseDesignPaths**:
+  - 見出しパス抽出: `### 3.1 タイトル (`path.ts`)` 形式
+  - インラインパス抽出: バッククォート内のパスパターン
+  - アーキテクチャ図パス抽出
+  - パスが重複する場合のデデュプ
+  - 空のdesign.md: 空のDesignPathsが返ること
+  - テンプレートのままのdesign.md: 空のDesignPathsが返ること
+- **overallStatus判定**:
+  - 全完了: complete
+  - コンポーネント0件: not-started
+  - 一部完了: partial
+  - Issue未設定時（total=0）のスキップ動作
+- **Issue状態チェック**: githubRepoのモックによる状態取得検証
+
+### 統合テスト
+
+- テスト用のspec-NNNNNN + design.md + 実装ファイルを用意し、検証結果が正確であることを確認
+- `--strict` モードでexit codeが1になること
+- `--json` 出力がJSON.parseableであること
+
+## 6. 技術的決定事項
+
+### design.mdからのパス抽出（正規表現ベース）
+
+**決定:** design.mdのテキストを正規表現でパースしてコンポーネントパスを抽出
+**理由:** design.mdは自然言語とMarkdown混在のドキュメントであり、構造化パーサーの適用が困難。reqordプロジェクトのdesign.mdは一定の記述規約（セクション見出し、バッククォート内パス、アーキテクチャ図内パス）に従っているため、正規表現による抽出が実用的。AI分析はコスト・レイテンシの観点から検証コマンドには不適切。
+
+### implementationフィールド非存在時のフォールバック
+
+**決定:** implementationフィールドが存在しない場合、Issueチェックをスキップし、コンポーネント・テストチェックのみ実行
+**理由:** Issue生成（spec-000016）はオプショナルな機能であり、すべてのSpecificationがIssueを持つとは限らない。Issueなしでも実装検証は有用であるため、部分的な検証を許容する。
+
+### strictモードのexit code
+
+**決定:** `--strict` オプション指定時、overallStatusが"complete"以外の場合にexit code 1を返す
+**理由:** CI/CDパイプラインでの利用を想定。PRマージ前に実装の完了度を自動検証し、未完了の場合にパイプラインを失敗させることで、不完全な実装のマージを防止する。

--- a/.reqord/specifications/spec-000019.json
+++ b/.reqord/specifications/spec-000019.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000019",
+  "requirementId": "req-000019",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:08.151Z",
+  "updatedAt": "2026-02-08T14:08:08.151Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000019/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000019/design.md
+++ b/.reqord/specifications/spec-000019/design.md
@@ -1,0 +1,346 @@
+# ステータス表示コマンド - 技術設計書
+
+## 1. 設計概要
+
+`reqord status` コマンドにより、プロジェクト全体の進捗ダッシュボードを提供する。Requirements・Specifications・GitHub Issuesの各カテゴリのステータス集計とASCIIプログレスバーで視覚的に進捗を表示する。`reqord status <req-id>` で要件単位の詳細ステータス（関連Specification・Gap Analysis結果）、`reqord status <spec-id>` で仕様単位の詳細（カバレッジ・Issue進捗）を表示する。`--json` と `--quiet`（CI用の数値のみ出力）オプションをサポートする。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/status.ts               (新規)
+                    ↓
+Service Layer:  services/status-service.ts        (新規)
+                    ↓
+Repository:     repositories/requirement.ts       (既存)
+                repositories/specification.ts     (既存)
+                repositories/project-context.ts   (既存)
+                    ↓
+Shared:         @reqord/shared
+                  schemas/requirement.ts          (既存: gapAnalysisフィールド参照)
+                  schemas/specification.ts        (既存: implementationフィールド参照)
+                    ↓
+Storage:        .reqord/requirements/req-NNNNNN.json
+                .reqord/specifications/spec-NNNNNN.json
+```
+
+集計ロジックをstatus-serviceに集約し、表示フォーマットはコマンド層に委譲する。リポジトリ層の既存findAll/findByIdメソッドを活用し、新規のリポジトリ追加は不要。
+
+## 3. コンポーネント設計
+
+### 3.1 statusコマンド (`commands/status.ts` - 新規)
+
+**責務:** ステータス表示のルーティングと出力フォーマット。
+
+```
+reqord status [<id>] [options]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `[<id>]` | 省略: プロジェクト全体、req-NNNNNN: 要件詳細、spec-NNNNNN: 仕様詳細 |
+| `--json` | 構造化JSON出力 |
+| `--quiet` | 数値のみ出力（CI用: `完了率%`） |
+
+**ID形式の判定:**
+```typescript
+function routeStatus(id?: string) {
+  if (!id) return showProjectStatus();
+  if (/^req-\d{6}$/.test(id)) return showRequirementStatus(id);
+  if (/^spec-\d{6}$/.test(id)) return showSpecificationStatus(id);
+  throw new Error(`不正なID形式: ${id}`);
+}
+```
+
+### 3.2 プロジェクト全体ステータス (`reqord status`)
+
+**表示形式:**
+```
+reqord プロジェクトステータス
+
+Requirements:
+  approved  ████████████░░░░░░░░  60% (6/10)
+  pending   ██░░░░░░░░░░░░░░░░░░  10% (1/10)
+  draft     ██████░░░░░░░░░░░░░░  30% (3/10)
+
+Specifications:
+  approved  ██████████░░░░░░░░░░  50% (4/8)
+  pending   ████░░░░░░░░░░░░░░░░  25% (2/8)
+  draft     ████░░░░░░░░░░░░░░░░  25% (2/8)
+
+Issues:
+  closed    ████████████████░░░░  80% (16/20)
+  open      ████░░░░░░░░░░░░░░░░  20% (4/20)
+
+⚠ 警告:
+  - req-000010: Gap Analysisが未実行です
+  - spec-000014: 設計検証が失敗しています（1 error）
+  - req-000012: 依存先 req-000011 が未承認です
+```
+
+### 3.3 StatusService (`services/status-service.ts` - 新規)
+
+**責務:** 各種ステータス情報の集計。
+
+```typescript
+export interface ProjectStatus {
+  requirements: StatusSummary;
+  specifications: StatusSummary;
+  issues: IssueSummary;
+  warnings: Warning[];
+  generatedAt: string;
+}
+
+export interface StatusSummary {
+  total: number;
+  byStatus: Record<string, number>;  // "draft": 3, "approved": 6, ...
+  approvedPercentage: number;
+}
+
+export interface IssueSummary {
+  total: number;
+  closed: number;
+  open: number;
+  closedPercentage: number;
+}
+
+export interface Warning {
+  id: string;
+  type: "gap-missing" | "validation-failed" | "blocked-dependency" | "no-specification";
+  message: string;
+}
+
+export async function getProjectStatus(cwd: string): Promise<ProjectStatus>;
+export async function getRequirementStatus(cwd: string, reqId: string): Promise<RequirementDetailStatus>;
+export async function getSpecificationStatus(cwd: string, specId: string): Promise<SpecificationDetailStatus>;
+```
+
+### 3.4 要件詳細ステータス (`reqord status <req-id>`)
+
+```typescript
+export interface RequirementDetailStatus {
+  requirement: Requirement;
+  specifications: Array<{
+    id: string;
+    status: string;
+  }>;
+  gapAnalysis: {
+    hasAnalysis: boolean;
+    coverage?: "full" | "partial" | "none";
+    missingCount?: number;
+    conflictCount?: number;
+  };
+  dependencyStatus: Array<{
+    id: string;
+    title: string;
+    status: string;
+    relation: "blockedBy" | "blocks" | "relatedTo";
+  }>;
+  issueProgress: {
+    total: number;
+    completed: number;
+  };
+}
+```
+
+**表示形式:**
+```
+要件ステータス: req-000016 (GitHub Issue生成)
+
+  ステータス:   approved
+  優先度:       high
+  複雑度:       large
+
+関連Specification:
+  spec-000016   approved
+
+Gap Analysis:
+  カバレッジ:   partial
+  不足機能:     3件
+  矛盾:         1件
+
+依存関係:
+  blockedBy:    req-000011 (approved) ✓
+  blockedBy:    req-000013 (approved) ✓
+  blocks:       req-000018 (draft)
+
+Issue進捗:  ████████████████░░░░  80% (4/5)
+```
+
+### 3.5 仕様詳細ステータス (`reqord status <spec-id>`)
+
+```typescript
+export interface SpecificationDetailStatus {
+  specification: Specification;
+  requirement: {
+    id: string;
+    title: string;
+    status: string;
+  };
+  designValidation?: {
+    passed: number;
+    warnings: number;
+    errors: number;
+  };
+  issueProgress: {
+    total: number;
+    completed: number;
+  };
+  coverageStatus: "covered" | "partial" | "not-covered";
+}
+```
+
+### 3.6 警告検出ロジック
+
+```typescript
+function detectWarnings(
+  requirements: Requirement[],
+  specifications: Specification[],
+): Warning[] {
+  const warnings: Warning[] = [];
+
+  for (const req of requirements) {
+    // Gap Analysisが未実行
+    if (!req.gapAnalysis && req.status === "approved") {
+      warnings.push({
+        id: req.id,
+        type: "gap-missing",
+        message: `Gap Analysisが未実行です`,
+      });
+    }
+
+    // Specificationが存在しない承認済み要件
+    const hasSpec = specifications.some(s => s.requirementId === req.id);
+    if (!hasSpec && req.status !== "draft") {
+      warnings.push({
+        id: req.id,
+        type: "no-specification",
+        message: `Specificationが作成されていません`,
+      });
+    }
+
+    // 依存先が未承認
+    for (const depId of req.dependencies.blockedBy) {
+      const dep = requirements.find(r => r.id === depId);
+      if (dep && dep.status !== "approved") {
+        warnings.push({
+          id: req.id,
+          type: "blocked-dependency",
+          message: `依存先 ${depId} が未承認です（現在: ${dep.status}）`,
+        });
+      }
+    }
+  }
+
+  for (const spec of specifications) {
+    // 設計検証が失敗
+    if (spec.designValidation && spec.designValidation.errors > 0) {
+      warnings.push({
+        id: spec.id,
+        type: "validation-failed",
+        message: `設計検証が失敗しています（${spec.designValidation.errors} error）`,
+      });
+    }
+  }
+
+  return warnings;
+}
+```
+
+### 3.7 ASCIIプログレスバー生成
+
+```typescript
+function renderProgressBar(percentage: number, width: number = 20): string {
+  const filled = Math.round(percentage / 100 * width);
+  const empty = width - filled;
+  return "█".repeat(filled) + "░".repeat(empty);
+}
+
+// 例: renderProgressBar(60) → "████████████░░░░░░░░"
+```
+
+## 4. データフロー
+
+### プロジェクト全体ステータス
+
+```
+ユーザー → reqord status
+  → statusCommand.action()
+    → statusService.getProjectStatus(cwd)
+      → reqRepo.findAll(cwd) → 全要件取得
+      → specRepo.findAll(cwd) → 全仕様取得
+      → Requirements集計:
+        → byStatus: { draft: 3, approved: 6, pending_approval: 1 }
+        → approvedPercentage: 60%
+      → Specifications集計:
+        → byStatus: { draft: 2, approved: 4, pending_approval: 2 }
+        → approvedPercentage: 50%
+      → Issues集計（各specのimplementationフィールドから）:
+        → total: 20, closed: 16, closedPercentage: 80%
+      → 警告検出:
+        → detectWarnings(requirements, specifications)
+      → ProjectStatus構築
+  → ASCIIダッシュボード表示
+```
+
+### 要件詳細ステータス
+
+```
+ユーザー → reqord status req-000016
+  → statusCommand.action("req-000016")
+    → statusService.getRequirementStatus(cwd, "req-000016")
+      → reqRepo.findById(cwd, "req-000016") → Requirement取得
+      → specRepo.findAll(cwd) → requirementIdでフィルタ → 関連Spec取得
+      → gapAnalysisフィールド読み取り
+      → 依存関係ステータス: blockedByの各要件のstatus取得
+      → Issue進捗: 関連Specのimplementationフィールドから集計
+    → RequirementDetailStatus返却
+  → 詳細表示
+```
+
+### quietモード
+
+```
+ユーザー → reqord status --quiet
+  → statusService.getProjectStatus(cwd)
+  → stdout: "60"  (Requirementsの承認率%のみ出力)
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **getProjectStatus**:
+  - 全要件draftの場合: approvedPercentage = 0
+  - 全要件approvedの場合: approvedPercentage = 100
+  - 要件0件の場合: total = 0, approvedPercentage = 0
+  - implementationフィールドがないSpecificationのIssue集計スキップ
+- **警告検出**:
+  - Gap Analysis未実行の承認済み要件
+  - 未承認の依存先がある要件
+  - Specificationが存在しない非draft要件
+  - 設計検証エラーがあるSpecification
+- **renderProgressBar**: 0%, 50%, 100%での正しいバー生成
+- **routeStatus**: req-NNNNNN/spec-NNNNNNの正しいルーティング、不正ID時のエラー
+
+### 統合テスト
+
+- テスト用のRequirement・Specification群を用意し、集計結果が正確であることを確認
+- `--json` 出力のスキーマ検証
+- `--quiet` 出力が数値のみであること
+
+## 6. 技術的決定事項
+
+### 単一コマンドでのルーティング
+
+**決定:** `reqord status [<id>]` の1コマンドで3種類の表示（全体/要件/仕様）を提供
+**理由:** 利便性のため。ユーザーはIDの有無と形式だけで表示内容を切り替えられる。サブコマンド（`reqord status project`, `reqord status req`等）に分割するとコマンド体系が冗長になる。
+
+### Issue集計のデータソース
+
+**決定:** SpecificationのimplementationフィールドからIssue情報を取得し、GitHub APIへのリアルタイム問い合わせは行わない
+**理由:** `reqord status` は高頻度で実行されるコマンドであり、毎回GitHub API呼び出しを行うとレイテンシが大きくなる。Issue同期（spec-000024で実装予定）により、implementationフィールドのstatusは定期的に更新される前提。リアルタイム情報が必要な場合は `reqord validate impl` を使用する。
+
+### 警告の自動検出
+
+**決定:** ステータス表示時に自動的に警告を検出・表示
+**理由:** ユーザーが個別の検証コマンド（validate, coverage等）を実行しなくても、`reqord status` だけでプロジェクトの潜在的な問題を把握できるようにする。ただし、警告検出はローカルデータのみを使用し、外部API呼び出しは行わない。

--- a/.reqord/specifications/spec-000020.json
+++ b/.reqord/specifications/spec-000020.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000020",
+  "requirementId": "req-000020",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:08.238Z",
+  "updatedAt": "2026-02-08T14:08:08.238Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000020/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000020/design.md
+++ b/.reqord/specifications/spec-000020/design.md
@@ -1,0 +1,284 @@
+# LLMコンテキスト出力コマンド - 技術設計書
+
+## 1. 設計概要
+
+`reqord context <req-id>` コマンドにより、指定された要件に関連するすべてのコンテキスト情報をLLM向けのMarkdown形式に集約して標準出力に出力する。ProjectContext（product/technical/structure）、Requirement（JSON + description.md）、Gap Analysis結果、関連Specification、依存要件をひとつのドキュメントに統合する。`--compact`（約2000トークン）と `--full`（約10000トークン）のモードでトークン量を制御し、パイプ経由でのLLM入力（`reqord context req-001 | claude code`）を主要ユースケースとする。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/context/export.ts       (新規)
+                    ↓
+Service Layer:  services/context-export-service.ts (新規)
+                    ↓
+Repository:     repositories/requirement.ts       (既存)
+                repositories/specification.ts     (既存)
+                repositories/project-context.ts   (既存)
+                    ↓
+File System:    repositories/file-system.ts       (既存)
+                    ↓
+Storage:        .reqord/context/ (ProjectContext)
+                .reqord/requirements/ (Requirement + description.md)
+                .reqord/specifications/ (Specification + design.md)
+```
+
+コンテキスト収集と出力フォーマットをサービス層に集約する。各種リポジトリの既存メソッド（findById, loadDescription, loadFile等）を組み合わせて情報を収集し、Markdownテンプレートに変換する。新規リポジトリは不要。
+
+## 3. コンポーネント設計
+
+### 3.1 exportコマンド (`commands/context/export.ts` - 新規)
+
+**責務:** コンテキスト出力のCLIインターフェース。
+
+```
+reqord context <req-id> [options]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<req-id>` | コンテキスト出力対象の要件ID（req-NNNNNN） |
+| `--full` | フルコンテキスト出力（約10000トークン、デフォルト） |
+| `--compact` | コンパクト出力（約2000トークン） |
+| `--format <type>` | 出力形式: markdown（デフォルト）、json |
+
+**注意:** 既存の `reqord context init/show/update` サブコマンドとの共存のため、IDの有無で動作を判定する。引数がreq-NNNNNN形式であればコンテキスト出力、サブコマンド（init/show/update）であれば既存コマンドにルーティングする。
+
+### 3.2 ContextExportService (`services/context-export-service.ts` - 新規)
+
+**責務:** 各種コンテキスト情報の収集とフォーマット。
+
+```typescript
+export type ExportMode = "full" | "compact";
+export type ExportFormat = "markdown" | "json";
+
+export interface ContextExportOptions {
+  mode: ExportMode;
+  format: ExportFormat;
+}
+
+export interface CollectedContext {
+  projectContext: {
+    product?: unknown;
+    technical?: unknown;
+    structure?: unknown;
+  };
+  requirement: {
+    json: Requirement;
+    description: string | null;
+  };
+  gapAnalysis?: {
+    coverage: string;
+    missingFeatures: Array<{ description: string; priority: string }>;
+    conflicts: Array<{ filePath: string; currentBehavior: string; requiredBehavior: string }>;
+  };
+  relatedSpecifications: Array<{
+    id: string;
+    status: string;
+    designSummary: string | null;
+  }>;
+  dependentRequirements: Array<{
+    id: string;
+    title: string;
+    status: string;
+    relation: string;
+  }>;
+}
+
+export async function exportContext(
+  cwd: string,
+  reqId: string,
+  options: ContextExportOptions,
+): Promise<string>;
+
+export async function collectContext(
+  cwd: string,
+  reqId: string,
+): Promise<CollectedContext>;
+```
+
+### 3.3 コンテキスト収集ロジック
+
+**収集対象と優先度:**
+
+| セクション | fullモード | compactモード |
+|-----------|-----------|-------------|
+| ProjectContext: product | 全文 | name + visionのみ |
+| ProjectContext: technical | 全文 | stack概要のみ |
+| ProjectContext: structure | 全文 | 省略 |
+| Requirement JSON | 全フィールド | id, title, status, successCriteria, format |
+| Requirement description.md | 全文 | 先頭500文字 |
+| Gap Analysis | 全詳細 | coverageとmissingFeatures概要 |
+| Related Specifications | design.mdの設計概要セクション | id + statusのみ |
+| Dependent Requirements | title + status + 関係性 | id + title + statusのみ |
+
+### 3.4 Markdownテンプレート
+
+**fullモード出力構造:**
+```markdown
+# LLMコンテキスト: {req.title}
+
+## プロジェクト情報
+
+### プロダクト
+{product.json の内容}
+
+### 技術スタック
+{technical.json の内容}
+
+### プロジェクト構造
+{structure.json の内容}
+
+## 対象要件: {req.id}
+
+### 基本情報
+- ID: {req.id}
+- タイトル: {req.title}
+- ステータス: {req.status}
+- 優先度: {req.priority}
+- フォーマット: {req.format.type}
+
+### 成功基準
+{successCriteria を番号付きリストで}
+
+### 要件詳細
+{description.md の内容}
+
+## Gap Analysis
+{gapAnalysis の詳細、存在する場合}
+
+## 関連仕様
+{各Specificationの設計概要}
+
+## 依存要件
+{blockedBy, blocks, relatedTo の要件リスト}
+```
+
+**compactモード出力構造:**
+```markdown
+# {req.title} (コンテキスト)
+
+## プロジェクト
+{product.name}: {product.vision}
+技術: {technical.stack の概要}
+
+## 要件: {req.id}
+ステータス: {req.status} | 優先度: {req.priority}
+
+成功基準:
+{successCriteria}
+
+{description.md の先頭500文字}
+
+## Gap: {gapAnalysis.coverage}
+不足: {missingFeaturesの概要リスト}
+
+## 関連
+{関連spec/reqのID + statusリスト}
+```
+
+### 3.5 JSONフォーマット出力
+
+`--format json` 指定時は `CollectedContext` オブジェクトをそのままJSON.stringifyして出力。パイプ先のツールがJSONパースする場合に使用。
+
+### 3.6 設計概要抽出ヘルパー
+
+```typescript
+function extractDesignSummary(designContent: string): string | null {
+  // "## 1. 設計概要" セクションの直下テキストを抽出
+  // 次の "## " が出現するまでの内容を返す
+  const match = designContent.match(
+    /##\s*1\.\s*設計概要\s*\n([\s\S]*?)(?=\n##\s|\n$|$)/
+  );
+  return match ? match[1].trim() : null;
+}
+```
+
+## 4. データフロー
+
+### fullモード出力フロー
+
+```
+ユーザー → reqord context req-000016 --full
+  → contextExportCommand.action("req-000016", { mode: "full" })
+    → contextExportService.exportContext(cwd, "req-000016", { mode: "full", format: "markdown" })
+      → collectContext(cwd, "req-000016")
+        → contextRepo.load(cwd) → ProjectContext取得
+        → contextRepo.loadContextFile(cwd, "product") → product.json
+        → contextRepo.loadContextFile(cwd, "technical") → technical.json
+        → contextRepo.loadContextFile(cwd, "structure") → structure.json
+        → reqRepo.findById(cwd, "req-000016") → Requirement取得
+        → reqRepo.loadDescription(cwd, "req-000016") → description.md
+        → requirement.gapAnalysis → Gap Analysis結果
+        → specRepo.findAll(cwd) → requirementIdでフィルタ → 関連Spec
+          → 各specのdesign.md → extractDesignSummary()
+        → 依存要件の取得:
+          → req.dependencies.blockedBy/blocks/relatedTo の各IDでfindById
+      → CollectedContext構築
+      → fullモードMarkdownテンプレート適用
+      → Markdown文字列返却
+  → process.stdout.write(output)
+```
+
+### パイプ使用フロー
+
+```
+ユーザー → reqord context req-000016 --compact | claude code
+  → exportContext(cwd, "req-000016", { mode: "compact", format: "markdown" })
+  → stdout: コンパクトMarkdown（約2000トークン）
+  → パイプ先のclaude codeに入力
+```
+
+### JSONフォーマットフロー
+
+```
+ユーザー → reqord context req-000016 --format json
+  → collectContext(cwd, "req-000016") → CollectedContext
+  → JSON.stringify(collectedContext, null, 2)
+  → stdout: JSON出力
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **collectContext**:
+  - 正常系: 全データが揃っている場合のCollectedContext構築
+  - ProjectContext未初期化時: projectContextフィールドが空オブジェクト
+  - Gap Analysis未実行時: gapAnalysisがundefined
+  - 関連Specificationが0件: 空配列
+  - 依存要件が存在しない場合のフォールバック
+- **extractDesignSummary**:
+  - 正常なdesign.md: 設計概要セクションの抽出
+  - テンプレートのみのdesign.md: null返却
+  - セクション見出しなし: null返却
+- **fullモードテンプレート**: 全セクションが出力に含まれること
+- **compactモードテンプレート**: 省略セクション（structure等）が含まれないこと、description.mdが500文字で切り詰められること
+- **JSONフォーマット**: JSON.parseableな出力であること
+
+### 統合テスト
+
+- テスト用のProjectContext + Requirement + Specification群を用意し、full/compactモードの出力検証
+- `--format json` 出力のスキーマ検証
+- stdoutへの出力が正しく行われること（stderr混入なし）
+
+## 6. 技術的決定事項
+
+### stdout専用出力
+
+**決定:** コンテキスト出力はstdoutのみに出力し、プログレス表示やメッセージはstderrに出力
+**理由:** パイプ経由でのLLM入力が主要ユースケースであるため、stdoutにはコンテキストのみを出力する必要がある。進捗表示や「出力しました」等のメッセージがstdoutに混入すると、パイプ先のツールで不要なテキストが入力されてしまう。
+
+### compact/fullの2段階モード
+
+**決定:** `--compact`（約2000トークン）と `--full`（約10000トークン）の2モードを提供
+**理由:** LLMのコンテキストウィンドウには制限がある。compactモードは小規模な質問やタスクに十分なコンテキストを提供し、fullモードは実装やレビューなど詳細な情報が必要なケースに対応する。中間モードの追加は将来的な拡張として、まず2段階で運用する。
+
+### 既存contextサブコマンドとの共存
+
+**決定:** `reqord context <req-id>` の引数がreq-NNNNNN形式であればコンテキスト出力、それ以外（init/show/update）は既存サブコマンドにルーティング
+**理由:** `reqord context export <req-id>` のようにサブコマンドを追加する案もあるが、パイプ使用時のタイピング量を最小化するため、直接ID指定でコンテキスト出力を行える設計とする。Commander.jsのサブコマンドとオプショナル引数の組み合わせで実現可能。
+
+### design.mdの設計概要のみ抽出
+
+**決定:** 関連Specificationのdesign.mdからは「設計概要」セクションのみを抽出
+**理由:** design.md全文を含めるとトークン量が大幅に増加する。設計概要セクションにはアプローチの要約が含まれており、LLMがタスクを理解するには十分。詳細設計が必要な場合はユーザーが個別にdesign.mdを参照する。

--- a/.reqord/specifications/spec-000021.json
+++ b/.reqord/specifications/spec-000021.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000021",
+  "requirementId": "req-000021",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:08.324Z",
+  "updatedAt": "2026-02-08T14:08:08.324Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000021/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000021/design.md
+++ b/.reqord/specifications/spec-000021/design.md
@@ -1,0 +1,297 @@
+# EARS形式変換コマンド - 技術設計書
+
+## 1. 設計概要
+
+`reqord req format <id> <target-format>` コマンドにより、要件のフォーマット（user-story / ears / free-form）を相互変換する。Anthropic SDK（Claude API）を使用して自然言語の要件記述を目標フォーマットに変換し、変換前後のdiffをユーザーに提示して確認後に適用する。EARS形式ではubiquitous, event-driven, state-driven, optional, unwantedの5タイプをサポートし、`--dry-run` でプレビューのみの実行も可能とする。
+
+## 2. アーキテクチャ
+
+```
+Command Layer:  commands/req/format.ts           (新規)
+                    ↓
+Service Layer:  services/format-service.ts        (新規)
+                    ↓
+Repository:     repositories/requirement.ts       (既存)
+                repositories/ai.ts               (spec-000016で追加)
+                    ↓
+External:       Anthropic API (Claude)
+                    ↓
+Shared:         @reqord/shared
+                  schemas/requirement.ts          (既存: FormatSchema)
+                    ↓
+Storage:        .reqord/requirements/req-NNNNNN.json
+```
+
+フォーマット変換ロジックをformat-serviceに集約し、AI呼び出しはspec-000016で導入するAIリポジトリを再利用する。変換プロンプトの構築とレスポンスのZodスキーマ検証をサービス層で行う。
+
+## 3. コンポーネント設計
+
+### 3.1 formatコマンド (`commands/req/format.ts` - 新規)
+
+**責務:** フォーマット変換の実行とdiff表示。
+
+```
+reqord req format <id> <target> [options]
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<id>` | 変換対象の要件ID（req-NNNNNN） |
+| `<target>` | 目標フォーマット: ears, user-story, free-form |
+| `--ears-type <type>` | EARS変換時のタイプ指定: ubiquitous, event-driven, state-driven, optional, unwanted |
+| `--dry-run` | 変換結果をプレビュー表示のみ（適用しない） |
+| `--json` | 構造化JSON出力 |
+
+### 3.2 FormatService (`services/format-service.ts` - 新規)
+
+**責務:** フォーマット変換のオーケストレーション。
+
+```typescript
+export type TargetFormat = "user-story" | "ears" | "free-form";
+export type EarsType = "ubiquitous" | "event-driven" | "state-driven" | "optional" | "unwanted";
+
+export interface FormatConversionOptions {
+  earsType?: EarsType;
+  dryRun?: boolean;
+}
+
+export interface FormatConversionResult {
+  requirementId: string;
+  before: {
+    format: Requirement["format"];
+    title: string;
+    description: string | null;
+  };
+  after: {
+    format: Requirement["format"];
+    title: string;
+    description: string | null;
+  };
+  applied: boolean;
+}
+
+export async function convertFormat(
+  cwd: string,
+  id: string,
+  target: TargetFormat,
+  options?: FormatConversionOptions,
+): Promise<FormatConversionResult>;
+```
+
+### 3.3 EARS形式の5タイプ
+
+**EARS (Easy Approach to Requirements Syntax) テンプレート:**
+
+| タイプ | テンプレート | 例 |
+|--------|------------|-----|
+| ubiquitous | The system shall {action} | The system shall validate all input fields |
+| event-driven | When {trigger}, the system shall {action} | When the user clicks submit, the system shall save the data |
+| state-driven | While {condition}, the system shall {action} | While the system is in maintenance mode, the system shall reject new connections |
+| optional | Where {feature}, the system shall {action} | Where multi-language support is enabled, the system shall display content in the user's locale |
+| unwanted | If {condition}, then the system shall {action} | If the API key is invalid, then the system shall return a 401 error |
+
+**EarsSchemaとの対応:**
+```typescript
+// 既存の @reqord/shared EarsSchema
+const EarsSchema = z.object({
+  type: z.string(),          // "ubiquitous" | "event-driven" | ...
+  trigger: z.string().optional(),    // event-driven: When {trigger}
+  condition: z.string().optional(),  // state-driven: While {condition}, unwanted: If {condition}
+  action: z.string(),               // 全タイプ共通: shall {action}
+  response: z.string().optional(),   // オプショナルな応答記述
+});
+```
+
+### 3.4 AI変換プロンプト設計
+
+**System Prompt:**
+```
+あなたは要件定義の専門家です。
+与えられた要件を指定されたフォーマットに変換してください。
+要件の意味を変えずに、フォーマットのみを変換します。
+出力は指定されたJSONスキーマに従ってください。
+```
+
+**User Prompt構築（例: user-story → ears変換）:**
+```
+## 現在の要件
+ID: {id}
+タイトル: {title}
+フォーマット: user-story
+  As: {userStory.as}
+  I want: {userStory.iWant}
+  So that: {userStory.soThat}
+
+説明:
+{description}
+
+成功基準:
+{successCriteria}
+
+## 変換先
+フォーマット: ears
+EARSタイプ: {earsType}
+
+## 出力
+以下のJSONスキーマに従って変換結果を出力してください:
+- format: EARSフォーマットオブジェクト
+- title: 変換後のタイトル（必要に応じて調整）
+- description: 変換後の説明文（必要に応じて調整）
+```
+
+**AIレスポンススキーマ:**
+```typescript
+const ConversionResponseSchema = z.object({
+  format: FormatSchema,  // 既存の FormatSchema を再利用
+  title: z.string().min(1),
+  description: z.string().optional(),
+});
+```
+
+### 3.5 diff表示
+
+**変換前後の差分表示:**
+```
+フォーマット変換: req-000016
+
+変換前:
+  フォーマット: user-story
+  As: 開発者
+  I want: SpecificationからGitHub Issueを自動生成したい
+  So that: 実装タスクの管理が効率化される
+
+変換後:
+  フォーマット: ears (event-driven)
+  Trigger: 開発者がSpecificationの実装タスク分解を要求したとき
+  Action: システムはSpecificationを解析しGitHub Issueを自動生成する
+
+タイトル変更:
+  - GitHub Issue生成
+  + Specificationからのevent-driven Issue自動生成
+
+この変換を適用しますか？ [y/N]
+```
+
+### 3.6 ユーザー確認フロー
+
+```typescript
+async function confirmConversion(
+  result: FormatConversionResult,
+): Promise<boolean> {
+  // diff表示
+  displayDiff(result.before, result.after);
+
+  // 対話的確認（--dry-runの場合はスキップ）
+  if (result.applied) return true;
+
+  const readline = await import("node:readline/promises");
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  const answer = await rl.question("この変換を適用しますか？ [y/N] ");
+  rl.close();
+  return answer.toLowerCase() === "y";
+}
+```
+
+### 3.7 同一フォーマットへの変換防止
+
+```typescript
+function validateConversion(
+  currentFormat: Requirement["format"],
+  target: TargetFormat,
+): void {
+  if (currentFormat.type === target) {
+    throw new Error(`要件は既に ${target} フォーマットです`);
+  }
+}
+```
+
+## 4. データフロー
+
+### フォーマット変換フロー
+
+```
+ユーザー → reqord req format req-000016 ears --ears-type event-driven
+  → formatCommand.action("req-000016", "ears", { earsType: "event-driven" })
+    → formatService.convertFormat(cwd, "req-000016", "ears", { earsType: "event-driven" })
+      → reqRepo.findById(cwd, "req-000016") → Requirement取得
+      → reqRepo.loadDescription(cwd, "req-000016") → description.md
+      → validateConversion(req.format, "ears") → 同一フォーマットでないことを確認
+      → AI変換プロンプト構築
+      → aiRepo.completeWithSchema(prompt, ConversionResponseSchema)
+        → Anthropic API呼び出し
+        → レスポンスをZodスキーマでパース
+      → FormatConversionResult構築（applied: false）
+    → diff表示
+    → ユーザー確認: "y"
+    → reqRepo.save(cwd, { ...req, format: result.after.format, title: result.after.title, updatedAt: now })
+    → reqRepo.saveDescription(cwd, id, result.after.description) （descriptionが変更された場合）
+  → 成功メッセージ: "フォーマットを変換しました: user-story → ears (event-driven)"
+```
+
+### dry-runフロー
+
+```
+ユーザー → reqord req format req-000016 ears --dry-run
+  → formatService.convertFormat(cwd, "req-000016", "ears", { dryRun: true })
+    → AI変換実行 → FormatConversionResult
+  → diff表示のみ（適用なし、確認プロンプトなし）
+  → "dry-runモード: 変換は適用されていません"
+```
+
+### free-formへの変換
+
+```
+ユーザー → reqord req format req-000016 free-form
+  → formatService.convertFormat(cwd, "req-000016", "free-form")
+    → AI変換: 構造化フォーマットからフリーフォームのタイトルと説明に変換
+    → format: { type: "free-form" }
+    → title, description の自然言語化
+  → diff表示 → 確認 → 適用
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **convertFormat**:
+  - user-story → ears: 全5タイプ（ubiquitous, event-driven, state-driven, optional, unwanted）
+  - ears → user-story: EarsSchemaからUserStorySchemaへの変換
+  - user-story → free-form: 構造の平坦化
+  - free-form → user-story: 自然言語からの構造化
+  - free-form → ears: 自然言語からEARS構造化
+  - ears → free-form: EARS構造の平坦化
+- **validateConversion**: 同一フォーマットでのエラー
+- **プロンプト構築**: 各フォーマットの情報がプロンプトに含まれること
+- **AIレスポンスパース**: 正常系・不正レスポンス時のエラーハンドリング
+
+### 統合テスト
+
+- テスト用のRequirementでフォーマット変換を実行し、JSON永続化が正しいことを確認（AIモック使用）
+- `--dry-run` モードでファイルが変更されないことの検証
+- `--json` 出力のスキーマ検証
+
+### AIモックテスト
+
+AIリポジトリをモック化し、事前定義された変換レスポンスでサービスロジックを検証。実際のAPI呼び出しはテストから除外する。
+
+## 6. 技術的決定事項
+
+### AI（Claude API）によるフォーマット変換
+
+**決定:** フォーマット変換にAnthropic SDK（Claude API）を使用
+**理由:** 自然言語で記述された要件を異なる構造形式に変換するには、文脈理解と自然言語生成が必要。ルールベースの変換（テンプレート穴埋め）では意味的な変換品質が不十分であり、特にfree-form↔構造化フォーマット間の変換にはLLMが適切。
+
+### 変換前のユーザー確認
+
+**決定:** 変換結果をdiff表示し、ユーザーの明示的な確認後に適用
+**理由:** AI生成の変換結果は意図しない意味の変化を含む可能性がある。Human-in-the-loopの原則に基づき、変換結果を確認してから適用することで、要件の品質を保証する。`--dry-run` オプションはプレビューのみで確認プロンプトも表示しない。
+
+### EarsTypeのオプション化
+
+**決定:** `--ears-type` は指定しない場合、AIが要件内容から最適なタイプを自動判定
+**理由:** ユーザーがEARSの5タイプの違いを熟知しているとは限らない。AIが要件の文脈（トリガーの有無、状態条件の有無等）を分析して最適なタイプを選択できる。明示的に指定された場合はそのタイプを使用する。
+
+### FormatSchemaの再利用
+
+**決定:** AIレスポンスの検証に既存の `@reqord/shared` FormatSchemaを使用
+**理由:** Requirement JSONのformatフィールドと同一のスキーマでAIレスポンスを検証することで、型の一貫性を保証する。AIが不正なフォーマットを返した場合はZodバリデーションで検出され、エラーメッセージを表示する。

--- a/.reqord/specifications/spec-000022.json
+++ b/.reqord/specifications/spec-000022.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000022",
+  "requirementId": "req-000022",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:08.410Z",
+  "updatedAt": "2026-02-08T14:08:08.410Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000022/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000022/design.md
+++ b/.reqord/specifications/spec-000022/design.md
@@ -1,0 +1,421 @@
+# Web UI ダッシュボード - 技術設計書
+
+## 1. 設計概要
+
+Next.js 15 App Routerのダッシュボードページとして、プロジェクト全体の健全性をビジュアルに表示する。Requirements承認率・Specifications承認率・Issues完了率のプログレスバー、カテゴリ別ステータスのサマリーカード、警告アラート（Gap Analysis未実行、検証失敗、ブロックされたIssue）、クリティカルパス残時間を一画面に集約する。データソースは `.reqord/` ファイルシステムから直接読み取り、バックエンドAPIは使用しない。本specはダッシュボードページのみを対象とし、ガントチャート（spec-000025）や依存関係グラフ拡張（spec-000026）は含まない。
+
+## 2. アーキテクチャ
+
+```
+packages/web/src/
+  ├── app/
+  │   ├── dashboard/
+  │   │   ├── page.tsx                  (ダッシュボードページ - 新規)
+  │   │   └── loading.tsx               (ローディングUI - 新規)
+  │   └── layout.tsx                    (既存: ナビゲーションにダッシュボードリンク追加)
+  ├── components/
+  │   ├── dashboard/                    (新規ディレクトリ)
+  │   │   ├── project-health.tsx        (プロジェクト健全性サマリー)
+  │   │   ├── progress-section.tsx      (プログレスバーセクション)
+  │   │   ├── progress-bar.tsx          (個別プログレスバー)
+  │   │   ├── status-cards.tsx          (ステータスサマリーカード群)
+  │   │   ├── status-card.tsx           (個別ステータスカード)
+  │   │   ├── warning-alerts.tsx        (警告アラートリスト)
+  │   │   ├── warning-alert.tsx         (個別警告アラート)
+  │   │   ├── critical-path-display.tsx (クリティカルパス表示)
+  │   │   └── status-chart.tsx          (Rechartsラッパー)
+  │   └── ui/
+  │       └── badge.tsx                 (既存)
+  └── lib/
+      ├── dashboard-data.ts             (ダッシュボードデータ取得 - 新規)
+      ├── specification-repository.ts   (Specificationデータ読み取り - 新規)
+      ├── data.ts                       (既存: Requirement読み取り)
+      └── local-repository.ts           (既存: ファイルI/O)
+```
+
+### データアクセスの流れ
+
+```
+ブラウザ → Next.js Server Component
+              ↓
+         lib/dashboard-data.ts (データ集約)
+              ↓
+         lib/data.ts (Requirements) + lib/specification-repository.ts (Specifications)
+              ↓
+         lib/file-system.ts → .reqord/ (ファイルシステム)
+```
+
+## 3. コンポーネント設計
+
+### 3.1 ページコンポーネント
+
+#### ダッシュボードページ (`dashboard/page.tsx`)
+
+- Server Componentとしてすべてのデータを取得
+- `dynamic = "force-dynamic"` でキャッシュ無効化
+- `<Suspense>` + `<Loading>` でストリーミング表示
+- ページ構成:
+  1. `<ProjectHealth>` - 全体サマリー
+  2. `<ProgressSection>` - 3つのプログレスバー
+  3. `<StatusCards>` - カテゴリ別ステータスカード
+  4. `<WarningAlerts>` - 警告アラート
+  5. `<CriticalPathDisplay>` - クリティカルパス残時間（データがある場合）
+
+```typescript
+export default async function DashboardPage() {
+  const dashboardData = await getDashboardData();
+
+  return (
+    <div className="space-y-8 p-6">
+      <h1 className="text-2xl font-bold">プロジェクトダッシュボード</h1>
+      <ProjectHealth data={dashboardData.health} />
+      <ProgressSection progress={dashboardData.progress} />
+      <StatusCards statuses={dashboardData.statusBreakdown} />
+      {dashboardData.warnings.length > 0 && (
+        <WarningAlerts warnings={dashboardData.warnings} />
+      )}
+      {dashboardData.criticalPath && (
+        <CriticalPathDisplay path={dashboardData.criticalPath} />
+      )}
+    </div>
+  );
+}
+```
+
+### 3.2 UIコンポーネント
+
+#### ProjectHealth (`components/dashboard/project-health.tsx`)
+
+**責務:** プロジェクト全体の健全性スコアと概要表示。
+
+```typescript
+interface ProjectHealthProps {
+  data: {
+    overallScore: number;        // 0-100の健全性スコア
+    requirementCount: number;
+    specificationCount: number;
+    issueCount: number;
+    lastUpdated: string;
+  };
+}
+```
+
+- 健全性スコア: 要件承認率(40%) + 仕様承認率(30%) + Issue完了率(30%) の加重平均
+- スコアに応じた色分け: 80以上=緑、50-79=黄、50未満=赤
+- Tailwind CSSによるカード表示
+
+#### ProgressSection (`components/dashboard/progress-section.tsx`)
+
+**責務:** 3つのプログレスバーをグリッド配置。
+
+```typescript
+interface ProgressSectionProps {
+  progress: {
+    requirements: { approved: number; total: number; percentage: number };
+    specifications: { approved: number; total: number; percentage: number };
+    issues: { completed: number; total: number; percentage: number };
+  };
+}
+```
+
+#### ProgressBar (`components/dashboard/progress-bar.tsx`)
+
+**責務:** 個別のプログレスバーの描画。
+
+```typescript
+interface ProgressBarProps {
+  label: string;
+  current: number;
+  total: number;
+  percentage: number;
+  color: "blue" | "green" | "purple";
+}
+```
+
+- Tailwind CSSの `bg-{color}-500` でバー色指定
+- `width: {percentage}%` のインラインスタイルで幅制御
+- `{current}/{total} ({percentage}%)` のラベル表示
+
+#### StatusCards (`components/dashboard/status-cards.tsx`)
+
+**責務:** カテゴリ別のステータス内訳をカードグリッドで表示。
+
+```typescript
+interface StatusCardsProps {
+  statuses: {
+    requirements: Record<string, number>;  // { draft: 3, approved: 6, ... }
+    specifications: Record<string, number>;
+    issues: Record<string, number>;        // { open: 4, closed: 16 }
+  };
+}
+```
+
+- 各カテゴリ（Requirements, Specifications, Issues）のカード
+- ステータス別の件数と色分けバッジ
+- spec-000007で定義した `<Badge>` コンポーネントを再利用
+
+#### StatusCard (`components/dashboard/status-card.tsx`)
+
+**責務:** 個別のステータスカード。
+
+```typescript
+interface StatusCardProps {
+  title: string;
+  breakdown: Record<string, number>;
+  colorMap: Record<string, string>;  // status → Tailwindカラークラス
+}
+```
+
+#### StatusChart (`components/dashboard/status-chart.tsx`)
+
+**責務:** Rechartsによるドーナツチャートの表示。
+
+```typescript
+"use client";
+
+interface StatusChartProps {
+  data: Array<{ name: string; value: number; fill: string }>;
+  title: string;
+}
+```
+
+- `"use client"` ディレクティブ（Rechartsはクライアントコンポーネント必須）
+- `<PieChart>` + `<Pie>` でドーナツチャート描画
+- 各ステータスの割合を視覚化
+
+#### WarningAlerts (`components/dashboard/warning-alerts.tsx`)
+
+**責務:** 警告アラートのリスト表示。
+
+```typescript
+interface WarningAlertsProps {
+  warnings: Array<{
+    id: string;
+    type: "gap-missing" | "validation-failed" | "blocked-dependency" | "no-specification";
+    message: string;
+    severity: "error" | "warning" | "info";
+  }>;
+}
+```
+
+- severity別のアイコンと色分け（error=赤、warning=黄、info=青）
+- 各警告にIDへのリンク（要件/仕様の詳細ページへ）
+- Tailwind CSSの `border-l-4` でサイドバー色表示
+
+#### WarningAlert (`components/dashboard/warning-alert.tsx`)
+
+**責務:** 個別の警告アラートカード。
+
+#### CriticalPathDisplay (`components/dashboard/critical-path-display.tsx`)
+
+**責務:** クリティカルパスの残時間と進捗表示。
+
+```typescript
+interface CriticalPathDisplayProps {
+  path: {
+    tasks: Array<{ title: string; estimatedHours: number; completed: boolean }>;
+    totalHours: number;
+    remainingHours: number;
+  };
+}
+```
+
+- タスクリスト表示（完了済み=打ち消し線、未完了=太字）
+- 残時間のプログレスバー
+
+### 3.3 データ層
+
+#### ダッシュボードデータ取得 (`lib/dashboard-data.ts` - 新規)
+
+**責務:** ダッシュボード表示に必要なデータの集約。
+
+```typescript
+export interface DashboardData {
+  health: {
+    overallScore: number;
+    requirementCount: number;
+    specificationCount: number;
+    issueCount: number;
+    lastUpdated: string;
+  };
+  progress: {
+    requirements: { approved: number; total: number; percentage: number };
+    specifications: { approved: number; total: number; percentage: number };
+    issues: { completed: number; total: number; percentage: number };
+  };
+  statusBreakdown: {
+    requirements: Record<string, number>;
+    specifications: Record<string, number>;
+    issues: Record<string, number>;
+  };
+  warnings: Array<{
+    id: string;
+    type: string;
+    message: string;
+    severity: "error" | "warning" | "info";
+  }>;
+  criticalPath: {
+    tasks: Array<{ title: string; estimatedHours: number; completed: boolean }>;
+    totalHours: number;
+    remainingHours: number;
+  } | null;
+}
+
+export async function getDashboardData(): Promise<DashboardData>;
+```
+
+**集計ロジック:**
+```typescript
+export async function getDashboardData(): Promise<DashboardData> {
+  const requirements = await getAllRequirements();
+  const specifications = await getAllSpecifications();
+
+  // Requirements集計
+  const reqByStatus = groupByStatus(requirements);
+  const reqApproved = reqByStatus.approved ?? 0;
+  const reqTotal = requirements.length;
+
+  // Specifications集計
+  const specByStatus = groupByStatus(specifications);
+  const specApproved = specByStatus.approved ?? 0;
+  const specTotal = specifications.length;
+
+  // Issues集計（各Specificationのimplementationフィールドから）
+  const allIssues = specifications
+    .filter(s => s.implementation)
+    .flatMap(s => s.implementation!.issues);
+  const issuesClosed = allIssues.filter(i => i.status === "closed").length;
+  const issuesTotal = allIssues.length;
+
+  // 健全性スコア
+  const reqPct = reqTotal > 0 ? reqApproved / reqTotal * 100 : 0;
+  const specPct = specTotal > 0 ? specApproved / specTotal * 100 : 0;
+  const issuePct = issuesTotal > 0 ? issuesClosed / issuesTotal * 100 : 0;
+  const overallScore = Math.round(reqPct * 0.4 + specPct * 0.3 + issuePct * 0.3);
+
+  // 警告検出
+  const warnings = detectWarnings(requirements, specifications);
+
+  // クリティカルパス（implementationフィールドから）
+  const criticalPath = extractCriticalPath(specifications);
+
+  return { health, progress, statusBreakdown, warnings, criticalPath };
+}
+```
+
+#### SpecificationRepository for Web (`lib/specification-repository.ts` - 新規)
+
+**責務:** Specificationデータのファイルシステム読み取り。
+
+```typescript
+import { SpecificationSchema, type Specification } from "@reqord/shared";
+
+export async function getAllSpecifications(): Promise<Specification[]>;
+export async function getSpecificationById(id: string): Promise<Specification | null>;
+```
+
+- `REQORD_ROOT` 環境変数で `.reqord/` ディレクトリを特定
+- spec-000007で実装したRequirement読み取りパターン（LocalRequirementRepository）と同様のファイルスキャン
+- `spec-\d{6}\.json` パターンマッチで全件取得
+
+### 3.4 ナビゲーション更新
+
+既存の `components/ui/nav.tsx` にダッシュボードリンクを追加:
+
+```typescript
+const navItems = [
+  { href: "/dashboard", label: "ダッシュボード" },  // 追加
+  { href: "/requirements", label: "要件一覧" },
+  { href: "/graph", label: "依存関係グラフ" },
+];
+```
+
+## 4. データフロー
+
+### ダッシュボード表示フロー
+
+```
+ブラウザ → /dashboard (GET)
+  → DashboardPage (Server Component)
+    → getDashboardData()
+      → getAllRequirements()
+        → LocalRequirementRepository.findAll()
+          → .reqord/requirements/req-*.json 読み込み
+      → getAllSpecifications()
+        → specificationRepository.findAll()
+          → .reqord/specifications/spec-*.json 読み込み
+      → Requirements集計: byStatus, approvedPercentage
+      → Specifications集計: byStatus, approvedPercentage
+      → Issues集計: 各spec.implementation.issues から
+      → 健全性スコア算出
+      → 警告検出
+      → クリティカルパス抽出
+    → DashboardData返却
+    → <ProjectHealth />
+    → <ProgressSection />
+    → <StatusCards />
+    → <WarningAlerts /> (warnings.length > 0の場合)
+    → <CriticalPathDisplay /> (criticalPath != nullの場合)
+  → HTML レスポンス
+```
+
+### 警告からの詳細ページ遷移
+
+```
+ブラウザ → ダッシュボード警告クリック
+  → 警告内のリンク:
+    → req-NNNNNN → /requirements/req-NNNNNN (既存ページ)
+    → spec-NNNNNN → /specifications/spec-NNNNNN (将来実装)
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **getDashboardData**:
+  - 正常系: Requirements/Specifications/Issuesの集計が正確であること
+  - 要件0件: total=0, percentage=0
+  - implementationフィールドなし: Issues集計がスキップされること
+  - 健全性スコア計算: 加重平均の正確性
+- **detectWarnings**:
+  - Gap Analysis未実行の承認済み要件
+  - 未承認の依存先がある要件
+  - Specificationなしの非draft要件
+  - 設計検証エラーのSpecification
+- **groupByStatus**: 各ステータスのカウントが正確であること
+- **extractCriticalPath**: implementationフィールドからのタスク抽出
+
+### コンポーネントテスト
+
+- **ProgressBar**: percentage=0/50/100での描画確認
+- **StatusCard**: breakdown propsに基づくバッジ表示
+- **WarningAlerts**: severity別の色分け表示
+- **StatusChart**: Rechartsコンポーネントのレンダリング（`"use client"` の正常動作）
+
+### 統合テスト
+
+- テスト用の `.reqord/` ディレクトリを用意し、ダッシュボードページの描画検証
+- CLIで要件/仕様を変更後、ダッシュボードに反映されること
+- 空プロジェクト（要件0件）での正常表示
+
+## 6. 技術的決定事項
+
+### Server Componentでの全データ取得
+
+**決定:** ダッシュボードページはServer Componentとし、すべてのデータをサーバーサイドで取得
+**理由:** spec-000007と同一の設計方針。ローカルファイルシステムへのアクセスはサーバーサイドでのみ可能。Requirements + Specifications + Issues の集計をサーバーサイドで完結させ、クライアントに送信するデータ量を最小化する。
+
+### Rechartsのクライアントコンポーネント分離
+
+**決定:** StatusChart（Recharts使用）のみ `"use client"` とし、他のコンポーネントはServer Componentを維持
+**理由:** Rechartsはブラウザ側のDOMに依存するため、クライアントコンポーネントとして実装する必要がある。ただし、データ取得はServer Component側で行い、チャートコンポーネントにはpropsとして集計済みデータのみを渡す。これにより、サーバーサイドでのファイルI/Oとクライアントサイドでの描画を適切に分離する。
+
+### SpecificationRepositoryの新規作成
+
+**決定:** Web版のSpecification読み取り用に新規リポジトリを作成（CLI版とは別実装）
+**理由:** spec-000007のRequirementと同様に、Web版はREQORD_ROOT環境変数ベース、CLI版はcwd引数ベースで動作する。既存のLocalRequirementRepositoryパターンを踏襲し、Specificationに特化した読み取り専用リポジトリを作成する。
+
+### ダッシュボードのスコープ限定
+
+**決定:** 本specではダッシュボードページのみを実装し、ガントチャート（spec-000025）や依存関係グラフ拡張（spec-000026）は含まない
+**理由:** ダッシュボードの基本機能（プログレスバー、サマリーカード、警告アラート）を早期にリリースし、ユーザーフィードバックを得てから高度な可視化機能を追加する。基盤となるデータ集計ロジック（getDashboardData）は共通化されるため、将来のspec実装時に再利用可能。

--- a/.reqord/specifications/spec-000023.json
+++ b/.reqord/specifications/spec-000023.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000023",
+  "requirementId": "req-000007",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:15.070Z",
+  "updatedAt": "2026-02-08T14:08:15.070Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000023/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000023/design.md
+++ b/.reqord/specifications/spec-000023/design.md
@@ -1,0 +1,266 @@
+# ローカルUI - 依存関係グラフ - 技術設計書
+
+## 1. 設計概要
+
+Next.js 15 App Router上で、Requirements間の依存関係をDAG（有向非巡回グラフ）として可視化する機能を提供する。既存実装（React Flow + カスタムDAGレイアウト）をベースに、ステータス別の色分け、ノードクリックによる詳細遷移、MiniMap・Controls等のインタラクティブ機能を統合する。本specはRequirementレベルの依存関係グラフに限定し、Specification/Issueレベルの拡張グラフはspec-000026で扱う。
+
+**既存実装の状況:**
+- `packages/web/src/app/graph/page.tsx` - グラフページ（Server Component）
+- `packages/web/src/components/graph/dependency-graph.tsx` - React Flowによるグラフ描画
+- `packages/web/src/components/graph/requirement-node.tsx` - カスタムノードコンポーネント
+- `packages/web/src/components/graph/dag-layout.ts` - トポロジカルソートベースのDAGレイアウト
+- `packages/web/src/components/graph/graph-loader.tsx` - SSR無効化のための動的ロード
+
+## 2. アーキテクチャ
+
+```
+packages/web/src/
+  ├── app/
+  │   └── graph/
+  │       ├── page.tsx                     (既存: Server Component)
+  │       └── loading.tsx                  (新規: ローディングUI)
+  ├── components/
+  │   └── graph/
+  │       ├── dependency-graph.tsx          (既存: React Flowメインコンポーネント)
+  │       ├── requirement-node.tsx          (既存: カスタムノード)
+  │       ├── dag-layout.ts                (既存: DAGレイアウトアルゴリズム)
+  │       ├── graph-loader.tsx             (既存: 動的インポートラッパー)
+  │       ├── graph-legend.tsx             (新規: ステータス凡例)
+  │       ├── graph-toolbar.tsx            (新規: フィルター・操作ツールバー)
+  │       └── node-detail-panel.tsx        (新規: ノード詳細パネル)
+  └── lib/
+      └── data.ts                          (既存: getAllRequirements)
+```
+
+### データアクセスの流れ
+
+```
+ブラウザ → /graph (GET)
+  → GraphPage (Server Component)
+    → getAllRequirements() → .reqord/requirements/ (ファイルシステム)
+  → GraphLoader (Client Component, dynamic import, ssr: false)
+    → DependencyGraph (Client Component)
+      → computeDagLayout() → LayoutNode[] + LayoutEdge[]
+      → React Flow描画
+```
+
+## 3. コンポーネント設計
+
+### 3.1 ページコンポーネント
+
+#### GraphPage (`app/graph/page.tsx` - 既存)
+
+- Server Componentとして全Requirementsを取得
+- `dynamic = "force-dynamic"` でキャッシュ無効化
+- `<GraphLoader>` にデータを渡す（SSR無効化のためdynamic importを使用）
+
+### 3.2 UIコンポーネント
+
+#### DependencyGraph (`components/graph/dependency-graph.tsx` - 既存)
+
+**責務:** React Flowを用いたグラフの描画とインタラクション管理。
+
+- `useMemo` で `computeDagLayout` を呼び出し、ノード・エッジを計算
+- `useNodesState` / `useEdgesState` でReact Flowの状態管理
+- `onInit` でfitViewを実行
+- `<Background>` / `<Controls>` / `<MiniMap>` の統合
+
+```typescript
+// 既存実装の拡張ポイント
+interface DependencyGraphProps {
+  requirements: Requirement[];
+  onNodeClick?: (requirementId: string) => void;  // 新規: ノードクリックハンドラ
+  filter?: {
+    status?: string[];        // 新規: ステータスフィルター
+    priority?: string[];      // 新規: 優先度フィルター
+  };
+}
+```
+
+#### RequirementNode (`components/graph/requirement-node.tsx` - 既存)
+
+**責務:** 個別ノードの描画。ステータス別の色分けとクリック遷移。
+
+```typescript
+// 既存のステータス色マッピング
+const STATUS_COLORS: Record<string, string> = {
+  draft: "border-gray-300 bg-gray-50",
+  pending_approval: "border-yellow-300 bg-yellow-50",
+  approved: "border-green-300 bg-green-50",
+  deprecated: "border-red-300 bg-red-50",
+};
+```
+
+- ノード幅: 220px固定
+- `<Handle>` でソース/ターゲット接続点を提供
+- `<Link>` で `/requirements/{id}` への遷移
+
+#### GraphLegend (`components/graph/graph-legend.tsx` - 新規)
+
+**責務:** ステータス色の凡例表示。
+
+```typescript
+interface GraphLegendProps {
+  className?: string;
+}
+```
+
+- 各ステータス（draft / pending_approval / approved / deprecated）の色サンプルとラベル
+- グラフ右下にオーバーレイ表示
+- Tailwind CSSによるコンパクトなカード表示
+
+#### GraphToolbar (`components/graph/graph-toolbar.tsx` - 新規)
+
+**責務:** ステータス・優先度によるフィルタリングUI。
+
+```typescript
+"use client";
+
+interface GraphToolbarProps {
+  onFilterChange: (filter: GraphFilter) => void;
+  currentFilter: GraphFilter;
+}
+
+interface GraphFilter {
+  statuses: string[];     // 空配列 = すべて表示
+  priorities: string[];   // 空配列 = すべて表示
+}
+```
+
+- チェックボックスまたはトグルボタンによるステータス・優先度フィルタ
+- フィルタ適用時にDependencyGraphの表示ノードを絞り込み
+- 「すべて表示」リセットボタン
+
+#### NodeDetailPanel (`components/graph/node-detail-panel.tsx` - 新規)
+
+**責務:** ノード選択時の詳細情報パネル。
+
+```typescript
+"use client";
+
+interface NodeDetailPanelProps {
+  requirement: Requirement | null;
+  onClose: () => void;
+}
+```
+
+- グラフ右側にスライドインするサイドパネル
+- 選択されたRequirementの基本情報表示（ID, タイトル, ステータス, 優先度）
+- blockedBy / blocks / relatedTo の依存関係リスト
+- 「詳細ページへ」リンクボタン
+
+### 3.3 レイアウトアルゴリズム
+
+#### computeDagLayout (`components/graph/dag-layout.ts` - 既存)
+
+**アルゴリズム:** トポロジカルソートベースの左→右DAGレイアウト。
+
+```
+1. 全Requirementsからエッジを構築（blockedBy関係）
+2. 入次数0のノードをルートとして初期化
+3. BFSでトポロジカルソート、各ノードの深度（最長パス）を計算
+4. 深度ごとにカラムを割り当て
+5. カラム内のノードをID順でソート（安定性のため）
+6. (x, y) = (col * (NODE_WIDTH + H_GAP), row * (NODE_HEIGHT + V_GAP))
+```
+
+**定数:**
+- `NODE_WIDTH = 240`
+- `NODE_HEIGHT = 80`
+- `HORIZONTAL_GAP = 80`
+- `VERTICAL_GAP = 40`
+
+**サイクル処理:** 循環依存が存在する場合、未処理ノードにdepth=0を割り当て（退化ケース）。
+
+## 4. データフロー
+
+### グラフ表示フロー
+
+```
+ブラウザ → /graph (GET)
+  → GraphPage (Server Component)
+    → getAllRequirements()
+      → getRepository() → LocalRequirementRepository
+        → findAll() → .reqord/requirements/req-*.json 読み込み
+    → <GraphLoader requirements={data} />
+  → HTML + Requirement[] データのシリアライゼーション
+
+ブラウザ (CSR)
+  → GraphLoader → DependencyGraph (dynamic import, ssr: false)
+    → computeDagLayout(requirements)
+      → エッジ構築: req.dependencies.blockedBy → edge[]
+      → トポロジカルソート → depth計算
+      → カラム・行レイアウト → LayoutNode[] + LayoutEdge[]
+    → React Flow初期化
+      → ノード描画: RequirementNode × N
+      → エッジ描画: animated=false, markerEnd=arrowclosed
+      → fitView() → 全体表示
+```
+
+### ノードクリック → 詳細遷移フロー
+
+```
+ノードクリック
+  → RequirementNode内の<Link href={`/requirements/${id}`}>
+  → Next.js App Routerによるページ遷移
+  → /requirements/[id]/page.tsx (Server Component)
+```
+
+### フィルタリングフロー
+
+```
+GraphToolbar: ステータスチェックボックス変更
+  → onFilterChange({ statuses: ["approved", "draft"] })
+  → DependencyGraph: 表示ノードのフィルタリング
+    → computeDagLayout(filteredRequirements)
+    → React Flow再描画
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **computeDagLayout**:
+  - 空配列: ノード0件、エッジ0件
+  - 依存関係なし: 全ノードがdepth=0（1カラム）
+  - 線形依存: A → B → C がdepth 0, 1, 2に配置
+  - 分岐依存: A → B, A → C がdepth 0, 1, 1に配置（Bと Cが同一カラム）
+  - 循環依存: サイクルノードがdepth=0にフォールバック
+  - 存在しないIDへの依存: 無効なblockedByエントリが無視されること
+- **GraphFilter ロジック**:
+  - ステータスフィルタ適用時のノード絞り込み
+  - 空フィルタ（全表示）の動作
+
+### コンポーネントテスト
+
+- **RequirementNode**: ステータス別の色クラスが適用されること
+- **GraphLegend**: 全ステータスの凡例が表示されること
+- **GraphToolbar**: フィルタ変更時にonFilterChangeが呼ばれること
+
+### 統合テスト
+
+- GraphPage: Server ComponentがRequirementsを取得し、GraphLoaderに渡すこと
+- 依存関係のある要件セットでグラフが正しく描画されること
+- ノードクリック → 詳細ページ遷移の動作確認
+
+## 6. 技術的決定事項
+
+### React Flow（@xyflow/react）の採用
+
+**決定:** グラフ描画にReact Flow（@xyflow/react）を使用
+**理由:** DAGの可視化に必要なノード描画、エッジ描画、パン・ズーム、MiniMap等の機能を標準で提供する。Reactエコシステムとの親和性が高く、カスタムノードの実装が容易。D3.jsやCytoscapeと比較して、Reactコンポーネントモデルに自然に統合できる。
+
+### SSR無効化（dynamic import + ssr: false）
+
+**決定:** DependencyGraphコンポーネントをdynamic importでSSR無効化
+**理由:** React FlowはブラウザDOMに依存するためサーバーサイドレンダリングが不可。`graph-loader.tsx` でnext/dynamicを使用し、`ssr: false` オプションで明示的にCSR限定とする。ローディング中はアニメーション付きプレースホルダーを表示。
+
+### カスタムDAGレイアウトアルゴリズム
+
+**決定:** React Flowの自動レイアウト（dagre等）ではなく、カスタムのトポロジカルソートベースレイアウトを使用
+**理由:** Requirementsの依存関係は比較的シンプルなDAG構造であり、dagreライブラリの追加依存を避けられる。最長パスベースの深度計算により、依存関係の階層が視覚的に明確になる。ノード数が数十程度の規模であり、カスタムアルゴリズムで十分なパフォーマンス。
+
+### Server Component + Client Component分離
+
+**決定:** ページレベルはServer Component（データ取得）、グラフ描画はClient Component
+**理由:** spec-000007と同一の設計方針。ファイルシステムからのデータ取得はサーバーサイドで完結させ、React Flowの描画はクライアントサイドで実行する。シリアライズ可能なRequirement[]をpropsとして渡すことで、Server/Client境界を明確にする。

--- a/.reqord/specifications/spec-000024.json
+++ b/.reqord/specifications/spec-000024.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000024",
+  "requirementId": "req-000016",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:15.153Z",
+  "updatedAt": "2026-02-08T14:08:15.153Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000024/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000024/design.md
+++ b/.reqord/specifications/spec-000024/design.md
@@ -1,0 +1,411 @@
+# GitHub Issue同期・進捗追跡 - 技術設計書
+
+## 1. 設計概要
+
+GitHub Issueの状態をローカルのSpecification JSONに同期し、実装進捗を追跡する機能を提供する。spec-000016で作成されたIssueの最新状態をGitHub APIから取得し、`implementation.issues[].state` および `implementation.progress` フィールドを更新する。`gh` CLIを通じたGitHub API呼び出しにより、追加の認証設定なしでIssue情報を取得する。メタデータの整合性検証（Issue存在確認、ラベル一致、循環依存チェック）も提供する。
+
+## 2. アーキテクチャ
+
+```
+packages/cli/src/
+  ├── commands/
+  │   └── issue/
+  │       ├── sync.ts                     (新規: syncコマンド)
+  │       └── validate.ts                 (新規: validateコマンド)
+  ├── services/
+  │   └── issue-sync-service.ts           (新規: 同期ビジネスロジック)
+  ├── repositories/
+  │   ├── specification.ts                (既存: Specification永続化)
+  │   └── github.ts                       (新規または既存: GitHub API呼び出し)
+  └── utils/
+      └── progress-calculator.ts          (新規: 進捗率計算)
+
+packages/shared/src/
+  └── schemas/
+      └── specification.ts                (既存: SpecificationSchemaの拡張)
+```
+
+### レイヤー構成
+
+```
+Command Layer:  commands/issue/sync.ts, commands/issue/validate.ts
+                    ↓
+Service Layer:  services/issue-sync-service.ts
+                    ↓
+Repository:     repositories/specification.ts (既存)
+                repositories/github.ts        (GitHub API)
+                    ↓
+External:       gh CLI → GitHub API
+                    ↓
+Storage:        .reqord/specifications/spec-NNNNNN.json
+```
+
+## 3. コンポーネント設計
+
+### 3.1 syncコマンド (`commands/issue/sync.ts` - 新規)
+
+**責務:** 単一/全SpecificationのIssue状態同期を実行し、結果を表示する。
+
+```
+reqord issue sync <spec-id>       # 個別Specificationの同期
+reqord issue sync-all             # 全Specificationの一括同期
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<spec-id>` | 対象のSpecification ID |
+| `--json` | 構造化JSON出力 |
+| `--verbose` | 変更されたフィールドの詳細表示 |
+
+**出力例（テーブル形式）:**
+
+```
+Syncing spec-000016...
+  Issue #42: "スキーマ定義"     open → closed  ✓
+  Issue #43: "Repository実装"   open → open    -
+  Issue #44: "Service実装"      open → open    -
+
+Progress: 1/3 (33%) completed
+```
+
+### 3.2 validateコマンド (`commands/issue/validate.ts` - 新規)
+
+**責務:** SpecificationとGitHub Issue間のメタデータ整合性を検証する。
+
+```
+reqord issue validate <spec-id>
+reqord issue validate --all
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `<spec-id>` | 対象のSpecification ID |
+| `--all` | 全Specificationの一括検証 |
+| `--json` | 構造化JSON出力 |
+| `--fix` | 自動修正可能な問題を修正 |
+
+**検証項目:**
+
+| チェック | 説明 | 深刻度 |
+|---------|------|--------|
+| Issue存在確認 | 記録されたIssue番号がGitHub上に存在するか | error |
+| ラベル一致 | `reqord-generated` ラベルが付与されているか | warning |
+| spec-idラベル | `spec:<spec-id>` ラベルが正しいか | warning |
+| 循環依存 | Issue間の依存関係に循環がないか | error |
+| 重複Issue | 同一タスクに対する重複Issueがないか | warning |
+| Issueオープン状態 | 全Issueクローズ済みならprogress=100%か | info |
+
+### 3.3 IssueSyncService (`services/issue-sync-service.ts` - 新規)
+
+**責務:** Issue同期のビジネスロジック。
+
+```typescript
+export interface SyncResult {
+  specId: string;
+  synced: SyncedIssue[];
+  progress: ProgressInfo;
+  errors: SyncError[];
+}
+
+export interface SyncedIssue {
+  number: number;
+  title: string;
+  previousState: string;
+  currentState: string;
+  changed: boolean;
+}
+
+export interface ProgressInfo {
+  total: number;
+  completed: number;
+  inProgress: number;
+  percentage: number;
+}
+
+export interface SyncError {
+  issueNumber: number;
+  message: string;
+  type: "not_found" | "api_error" | "parse_error";
+}
+
+// 個別Specificationの同期
+export async function syncSpecification(
+  cwd: string,
+  specId: string,
+): Promise<SyncResult>;
+
+// 全Specificationの一括同期
+export async function syncAll(
+  cwd: string,
+): Promise<SyncResult[]>;
+```
+
+**同期ロジック:**
+
+```typescript
+async function syncSpecification(cwd: string, specId: string): Promise<SyncResult> {
+  // 1. Specification JSONを読み込み
+  const spec = await specRepo.findById(cwd, specId);
+  if (!spec?.implementation?.issues) {
+    throw new Error(`No issues found for ${specId}`);
+  }
+
+  // 2. 各IssueのGitHub状態を取得
+  const synced: SyncedIssue[] = [];
+  for (const issue of spec.implementation.issues) {
+    const ghIssue = await githubRepo.getIssue(cwd, issue.number);
+    synced.push({
+      number: issue.number,
+      title: issue.title,
+      previousState: issue.status,
+      currentState: mapGitHubState(ghIssue.state),
+      changed: issue.status !== mapGitHubState(ghIssue.state),
+    });
+  }
+
+  // 3. 進捗率を計算
+  const progress = calculateProgress(synced);
+
+  // 4. Specification JSONを更新
+  await updateSpecificationProgress(cwd, specId, synced, progress);
+
+  return { specId, synced, progress, errors: [] };
+}
+```
+
+### 3.4 GitHubRepository (`repositories/github.ts` - 新規または拡張)
+
+**責務:** `gh` CLI経由でのGitHub API呼び出し。
+
+```typescript
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  labels: string[];
+  assignees: string[];
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+}
+
+// 個別Issue取得
+export async function getIssue(
+  cwd: string,
+  issueNumber: number,
+): Promise<GitHubIssue>;
+
+// 複数Issue一括取得（ラベルフィルタ）
+export async function listIssues(
+  cwd: string,
+  options: { labels?: string[]; state?: "open" | "closed" | "all" },
+): Promise<GitHubIssue[]>;
+```
+
+**gh CLI呼び出し:**
+
+```typescript
+import { execFile } from "node:child_process";
+
+async function getIssue(cwd: string, issueNumber: number): Promise<GitHubIssue> {
+  const result = await execGh(cwd, [
+    "issue", "view", String(issueNumber),
+    "--json", "number,title,state,labels,assignees,createdAt,updatedAt,closedAt",
+  ]);
+  return parseGitHubIssue(JSON.parse(result));
+}
+
+async function listIssues(cwd: string, options: ListOptions): Promise<GitHubIssue[]> {
+  const args = ["issue", "list", "--json", "number,title,state,labels,assignees,createdAt,updatedAt,closedAt"];
+  if (options.labels?.length) {
+    args.push("--label", options.labels.join(","));
+  }
+  if (options.state) {
+    args.push("--state", options.state);
+  }
+  const result = await execGh(cwd, args);
+  return JSON.parse(result).map(parseGitHubIssue);
+}
+```
+
+### 3.5 ProgressCalculator (`utils/progress-calculator.ts` - 新規)
+
+**責務:** Issue状態からの進捗率計算。
+
+```typescript
+export function calculateProgress(issues: SyncedIssue[]): ProgressInfo {
+  const total = issues.length;
+  const completed = issues.filter(i => i.currentState === "closed").length;
+  const inProgress = issues.filter(i =>
+    i.currentState === "open" &&
+    // assigneesが設定されている場合をin_progressとみなす
+    // （GitHub APIから取得した追加情報で判定）
+    false  // 基本実装ではopen/closedのみで判定
+  ).length;
+  const percentage = total > 0 ? Math.round((completed / total) * 100) : 0;
+  return { total, completed, inProgress, percentage };
+}
+```
+
+### 3.6 SpecificationSchema拡張
+
+spec-000016で追加される `implementation` フィールドに対し、本specで以下のフィールドを利用・更新する:
+
+```typescript
+// spec-000016で定義済みのフィールド（本specが更新対象とする）
+implementation: z.object({
+  issues: z.array(z.object({
+    number: z.number(),
+    title: z.string(),
+    url: z.string(),
+    priority: z.string(),
+    status: z.enum(["open", "in_progress", "closed"]).default("open"),
+  })),
+  strategy: z.string(),
+  totalEstimatedHours: z.number(),
+  createdAt: z.string(),
+  // 本specで追加するフィールド
+  progress: z.object({
+    total: z.number(),
+    completed: z.number(),
+    percentage: z.number(),
+    lastSyncedAt: z.string(),
+  }).optional(),
+}).optional(),
+```
+
+### 3.7 GitHub状態のマッピング
+
+```typescript
+function mapGitHubState(ghState: "open" | "closed"): "open" | "in_progress" | "closed" {
+  // GitHub APIではopen/closedの2状態のみ
+  // in_progressはGitHub Projectsのカスタムフィールドに依存するため、
+  // 基本実装ではopen/closedのみを使用
+  switch (ghState) {
+    case "open": return "open";
+    case "closed": return "closed";
+  }
+}
+```
+
+## 4. データフロー
+
+### 個別同期フロー
+
+```
+ユーザー → reqord issue sync spec-000016
+  → syncCommand.action("spec-000016")
+    → issueSyncService.syncSpecification(cwd, "spec-000016")
+      → specRepo.findById(cwd, "spec-000016") → Specification取得
+        → implementation.issues = [#42, #43, #44]
+      → 各Issueについて:
+        → githubRepo.getIssue(cwd, 42)
+          → gh issue view 42 --json ... → GitHubIssue
+        → previousState vs currentState 比較
+      → calculateProgress(synced)
+        → { total: 3, completed: 1, percentage: 33 }
+      → specRepo.save(cwd, updatedSpec)
+        → implementation.issues[0].status = "closed"
+        → implementation.progress = { total: 3, completed: 1, percentage: 33, lastSyncedAt: "..." }
+    → SyncResult返却
+  → テーブル表示
+```
+
+### 一括同期フロー
+
+```
+ユーザー → reqord issue sync-all
+  → syncAllCommand.action()
+    → specRepo.findAll(cwd) → 全Specification取得
+    → implementationフィールドを持つspecをフィルタ
+    → 各specに対して syncSpecification() を順次実行
+    → 全SyncResult[] を集約
+  → サマリーテーブル表示:
+    | Spec ID      | Issues | Completed | Progress |
+    | spec-000016  | 3      | 1         | 33%      |
+    | spec-000017  | 5      | 5         | 100%     |
+```
+
+### 検証フロー
+
+```
+ユーザー → reqord issue validate spec-000016
+  → validateCommand.action("spec-000016")
+    → issueSyncService.validateSpecification(cwd, "spec-000016")
+      → specRepo.findById(cwd, "spec-000016") → Specification取得
+      → 各Issueについて:
+        → githubRepo.getIssue(cwd, issue.number) → Issue存在確認
+        → ラベル確認: "reqord-generated", "spec:spec-000016" が存在するか
+      → 循環依存チェック:
+        → Issue間のblockedBy関係をグラフとして構築
+        → トポロジカルソートで循環検出
+      → 重複チェック:
+        → 同一タイトルのIssueがないか
+    → ValidationResult返却
+  → 検証結果表示:
+    ✓ Issue #42 exists
+    ✓ Issue #43 exists
+    ⚠ Issue #43 missing label "spec:spec-000016"
+    ✓ No circular dependencies
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **issueSyncService.syncSpecification**:
+  - 正常系: 3件のIssueのうち1件がclosed → progress 33%
+  - 全件closed: progress 100%
+  - 全件open: progress 0%
+  - implementationフィールドなし: エラーメッセージ
+  - GitHub API応答エラー: SyncErrorとして記録
+- **issueSyncService.validateSpecification**:
+  - 全チェック正常: ValidationResult.errors = []
+  - Issue不存在: error severity
+  - ラベル不一致: warning severity
+  - 循環依存検出: error severity
+- **calculateProgress**:
+  - 0件: percentage = 0
+  - 全件closed: percentage = 100
+  - 部分的closed: 正しいパーセンテージ計算
+- **mapGitHubState**:
+  - open → "open"
+  - closed → "closed"
+
+### 統合テスト
+
+- **GitHubRepository（モック）**:
+  - `gh` CLI呼び出しのモック化
+  - JSON応答のパース検証
+  - エラーハンドリング（Issue不存在、権限エラー）
+- **sync → save フロー**:
+  - 同期結果がSpecification JSONに正しく書き込まれること
+  - progressフィールドの更新値検証
+  - lastSyncedAtのタイムスタンプ更新
+
+### E2Eテスト（手動）
+
+- 実際のGitHubリポジトリでのsync動作確認
+- GitHub Issueの状態変更 → sync → JSON更新の一連フロー
+
+## 6. 技術的決定事項
+
+### gh CLIの採用（Octokit.jsではなく）
+
+**決定:** GitHub APIへのアクセスに `gh` CLI を使用（Octokit.jsライブラリではなく）
+**理由:** `gh` CLIはユーザーの既存認証情報を利用でき、追加のトークン設定が不要。CLIツールであるreqordのユーザーは `gh` CLIをインストール済みである可能性が高い。Octokit.jsの場合、個人アクセストークンの管理が必要となり、セキュリティリスクと設定の手間が増える。`gh` の `--json` オプションにより構造化された出力を取得可能。
+
+### 同期の単方向性
+
+**決定:** 同期はGitHub → ローカルの一方向のみ
+**理由:** ローカルのSpecification JSONはGitHub Issueの「キャッシュ」としての役割を持つ。ローカルでのステータス変更をGitHubに反映する逆方向の同期は、意図しないIssueの状態変更リスクがある。Human-in-the-loopの原則に基づき、GitHub Issueの操作はGitHub UI上で人間が直接行うべき。
+
+### in_progress状態の簡易実装
+
+**決定:** 初期実装では `open` / `closed` の2状態のみを使用し、`in_progress` はGitHub Projectsとの統合として将来対応
+**理由:** GitHub REST APIではIssueの状態は `open` / `closed` のみ。`in_progress` の判定にはGitHub Projectsの `Status` カスタムフィールドへのアクセスが必要で、GraphQL APIの使用が前提となる。初期実装ではシンプルにopen/closedの同期に集中し、Projects統合は将来のspecで扱う。
+
+### progressフィールドの追加
+
+**決定:** `implementation.progress` オブジェクトを追加し、集計済みの進捗情報をJSON内に保持
+**理由:** ダッシュボード（spec-000022）やガントチャート（spec-000025）など複数のコンシューマーが進捗情報を参照する。毎回全Issueのstateをカウントするのではなく、同期時に計算済みの進捗を保持することで、読み取り側の実装がシンプルになる。`lastSyncedAt` によりデータの鮮度も確認可能。

--- a/.reqord/specifications/spec-000025.json
+++ b/.reqord/specifications/spec-000025.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000025",
+  "requirementId": "req-000022",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:15.243Z",
+  "updatedAt": "2026-02-08T14:08:15.243Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000025/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000025/design.md
+++ b/.reqord/specifications/spec-000025/design.md
@@ -1,0 +1,382 @@
+# Web UI - Ganttチャート - 技術設計書
+
+## 1. 設計概要
+
+Next.js 15 App Router上で、SpecificationごとのGitHub Issue進捗をGanttチャートとして可視化する機能を提供する。並列グループ（P0/P1/P2）ごとのレイアウト、Issue状態に応じた色分け、見積もり時間ベースのバー幅、クリティカルパスのハイライトを実装する。Specification詳細ページのIssuesタブ内に配置し、spec-000024の同期データ（`implementation` フィールド）をデータソースとする。SVGベースのカスタム実装により、外部Ganttライブラリへの依存を回避する。
+
+## 2. アーキテクチャ
+
+```
+packages/web/src/
+  ├── app/
+  │   └── specifications/
+  │       └── [id]/
+  │           └── page.tsx                   (spec-000026で新規: Spec詳細ページ)
+  ├── components/
+  │   └── gantt/                             (新規ディレクトリ)
+  │       ├── gantt-chart.tsx                (メインGanttチャートコンポーネント)
+  │       ├── gantt-bar.tsx                  (個別タスクバー)
+  │       ├── gantt-header.tsx               (タイムライン・ヘッダー)
+  │       ├── gantt-group.tsx                (並列グループ表示)
+  │       ├── gantt-critical-path.tsx        (クリティカルパスオーバーレイ)
+  │       ├── gantt-legend.tsx               (凡例)
+  │       └── gantt-tooltip.tsx              (ツールチップ)
+  └── lib/
+      ├── gantt-data.ts                      (新規: Ganttデータ変換)
+      ├── specification-repository.ts        (spec-000022で新規: Specification読み取り)
+      └── data.ts                            (既存: Requirement読み取り)
+```
+
+### データアクセスの流れ
+
+```
+ブラウザ → /specifications/[id] (GET)
+  → SpecificationDetailPage (Server Component)
+    → getSpecificationById(id) → Specification JSON取得
+      → implementation.issues, implementation.progress 読み取り
+    → transformToGanttData() → GanttData変換
+  → GanttChart (Client Component)
+    → SVG描画
+```
+
+## 3. コンポーネント設計
+
+### 3.1 データ変換層
+
+#### gantt-data.ts (`lib/gantt-data.ts` - 新規)
+
+**責務:** Specification JSONの `implementation` フィールドからGanttチャート表示用のデータに変換する。
+
+```typescript
+export interface GanttData {
+  specId: string;
+  groups: GanttGroup[];
+  criticalPath: string[];       // タスクタイトルの配列
+  totalEstimatedHours: number;
+  timelineStart: number;        // 0起点（時間単位）
+  timelineEnd: number;          // 全タスクの最大終了時間
+}
+
+export interface GanttGroup {
+  priority: "P0" | "P1" | "P2";
+  label: string;                // "P0: Sequential" / "P1: Parallel" / "P2: Parallel"
+  tasks: GanttTask[];
+}
+
+export interface GanttTask {
+  id: string;                   // Issue番号ベース: "issue-42"
+  title: string;
+  issueNumber: number;
+  issueUrl: string;
+  priority: "P0" | "P1" | "P2";
+  state: "completed" | "in_progress" | "blocked" | "pending";
+  estimatedHours: number;
+  startOffset: number;          // グループ内開始オフセット（時間単位）
+  dependencies: string[];       // 依存先タスクID
+  isCriticalPath: boolean;
+}
+
+export function transformToGanttData(
+  specId: string,
+  implementation: Implementation,
+): GanttData;
+```
+
+**変換ロジック:**
+
+```typescript
+function transformToGanttData(specId: string, implementation: Implementation): GanttData {
+  const tasks = implementation.issues;
+
+  // 1. 優先度別にグループ分け
+  const p0Tasks = tasks.filter(t => t.priority === "P0");
+  const p1Tasks = tasks.filter(t => t.priority === "P1");
+  const p2Tasks = tasks.filter(t => t.priority === "P2");
+
+  // 2. P0: 直列配置（依存関係に従い、累積startOffsetを計算）
+  let p0Offset = 0;
+  const p0Gantt = p0Tasks.map(t => {
+    const task = toGanttTask(t, p0Offset);
+    p0Offset += t.estimatedHours ?? DEFAULT_HOURS;
+    return task;
+  });
+
+  // 3. P1: 並列配置（P0完了後に開始、全タスクのstartOffsetはP0合計時間）
+  const p1Start = p0Offset;
+  const p1Gantt = p1Tasks.map(t => toGanttTask(t, p1Start));
+
+  // 4. P2: 並列配置（P1の最長タスク完了後に開始）
+  const p1MaxEnd = p1Start + Math.max(...p1Tasks.map(t => t.estimatedHours ?? DEFAULT_HOURS), 0);
+  const p2Start = p1Tasks.length > 0 ? p1MaxEnd : p1Start;
+  const p2Gantt = p2Tasks.map(t => toGanttTask(t, p2Start));
+
+  // 5. タイムラインの範囲計算
+  const allGanttTasks = [...p0Gantt, ...p1Gantt, ...p2Gantt];
+  const timelineEnd = Math.max(...allGanttTasks.map(t => t.startOffset + t.estimatedHours), 0);
+
+  return {
+    specId,
+    groups: [
+      { priority: "P0", label: "P0: Sequential", tasks: p0Gantt },
+      { priority: "P1", label: "P1: Parallel", tasks: p1Gantt },
+      { priority: "P2", label: "P2: Parallel", tasks: p2Gantt },
+    ].filter(g => g.tasks.length > 0),
+    criticalPath: implementation.criticalPath ?? [],
+    totalEstimatedHours: implementation.totalEstimatedHours,
+    timelineStart: 0,
+    timelineEnd,
+  };
+}
+```
+
+### 3.2 UIコンポーネント
+
+#### GanttChart (`components/gantt/gantt-chart.tsx` - 新規)
+
+**責務:** Ganttチャート全体のSVG描画とインタラクション管理。
+
+```typescript
+"use client";
+
+interface GanttChartProps {
+  data: GanttData;
+  className?: string;
+}
+```
+
+- `"use client"` ディレクティブ（SVGインタラクション、ツールチップ表示のため）
+- SVG要素でチャート全体を描画
+- 横軸: 時間（時間単位）、縦軸: タスク行
+- グループヘッダー + タスクバー + クリティカルパスオーバーレイの3レイヤー構成
+- レスポンシブ: コンテナ幅に応じて時間軸のスケールを調整
+
+**SVGレイアウト定数:**
+
+```typescript
+const GANTT_CONFIG = {
+  ROW_HEIGHT: 36,              // 各タスク行の高さ
+  BAR_HEIGHT: 24,              // バーの高さ
+  BAR_Y_OFFSET: 6,            // 行内のバーY位置オフセット
+  GROUP_HEADER_HEIGHT: 28,     // グループヘッダーの高さ
+  LEFT_LABEL_WIDTH: 200,       // 左側のタスクラベル領域幅
+  HEADER_HEIGHT: 40,           // タイムラインヘッダーの高さ
+  HOUR_WIDTH: 60,              // 1時間あたりのピクセル幅
+  PADDING: 16,                 // 左右パディング
+};
+```
+
+#### GanttBar (`components/gantt/gantt-bar.tsx` - 新規)
+
+**責務:** 個別タスクバーのSVG描画。
+
+```typescript
+interface GanttBarProps {
+  task: GanttTask;
+  y: number;
+  hourWidth: number;
+  onHover: (task: GanttTask | null) => void;
+  onClick: (task: GanttTask) => void;
+}
+```
+
+**状態別の色分け:**
+
+| 状態 | 色 | Tailwind/SVGカラー |
+|------|-----|-----------------|
+| completed | 緑 | `#22c55e` (green-500) |
+| in_progress | 青 | `#3b82f6` (blue-500) |
+| blocked | 赤 | `#ef4444` (red-500) |
+| pending | グレー | `#9ca3af` (gray-400) |
+
+- `<rect>` でバーを描画、角丸 `rx=4`
+- `<text>` でバー内にタスクタイトル表示（バー幅が十分な場合）
+- マウスオーバーでツールチップ表示
+- クリックでIssue URLを新規タブで開く
+
+#### GanttHeader (`components/gantt/gantt-header.tsx` - 新規)
+
+**責務:** タイムラインヘッダーの描画。
+
+```typescript
+interface GanttHeaderProps {
+  timelineStart: number;
+  timelineEnd: number;
+  hourWidth: number;
+}
+```
+
+- 時間目盛り: 1h, 2h, 3h, ... のラベル表示
+- グリッド線: 各時間位置に縦の点線
+
+#### GanttGroup (`components/gantt/gantt-group.tsx` - 新規)
+
+**責務:** 優先度グループのヘッダーと区切り表示。
+
+```typescript
+interface GanttGroupProps {
+  group: GanttGroup;
+  y: number;
+  width: number;
+}
+```
+
+- グループラベル（"P0: Sequential" 等）の表示
+- グループ間の区切り線
+- 背景色のストライピング（グループ識別用）
+
+#### GanttCriticalPath (`components/gantt/gantt-critical-path.tsx` - 新規)
+
+**責務:** クリティカルパスのハイライト表示。
+
+```typescript
+interface GanttCriticalPathProps {
+  tasks: GanttTask[];
+  hourWidth: number;
+  rowPositions: Map<string, number>;  // taskId → y位置
+}
+```
+
+- クリティカルパス上のタスクバーに太い赤枠線をオーバーレイ
+- タスク間を接続する矢印線の描画
+- ツールチップ: 「クリティカルパス: 残りX時間」
+
+#### GanttLegend (`components/gantt/gantt-legend.tsx` - 新規)
+
+**責務:** 状態色の凡例表示。
+
+```typescript
+interface GanttLegendProps {
+  className?: string;
+}
+```
+
+- 4つの状態（completed / in_progress / blocked / pending）の色サンプルとラベル
+- チャートの上部または下部に配置
+
+#### GanttTooltip (`components/gantt/gantt-tooltip.tsx` - 新規)
+
+**責務:** タスクバーホバー時のツールチップ。
+
+```typescript
+interface GanttTooltipProps {
+  task: GanttTask | null;
+  position: { x: number; y: number };
+}
+```
+
+- タスクタイトル、Issue番号、状態、見積もり時間、依存関係を表示
+- マウス位置に追従するフローティングカード
+
+## 4. データフロー
+
+### Ganttチャート表示フロー
+
+```
+ブラウザ → /specifications/[id] (GET)
+  → SpecificationDetailPage (Server Component)
+    → getSpecificationById(id)
+      → .reqord/specifications/spec-NNNNNN.json 読み込み
+      → implementation フィールド取得
+    → transformToGanttData(specId, implementation)
+      → Priority別グループ分け
+      → P0: 直列配置 → startOffset累積計算
+      → P1: 並列配置 → P0終了時点から開始
+      → P2: 並列配置 → P1最長タスク終了後から開始
+      → criticalPathフラグの付与
+      → GanttData返却
+    → <GanttChart data={ganttData} />
+  → HTML + GanttDataのシリアライゼーション
+
+ブラウザ (CSR)
+  → GanttChart (Client Component)
+    → SVG描画:
+      → GanttHeader: タイムライン目盛り
+      → GanttGroup × N: グループヘッダー
+      → GanttBar × M: タスクバー（色分け済み）
+      → GanttCriticalPath: ハイライトオーバーレイ
+```
+
+### バーホバー → ツールチップ表示フロー
+
+```
+マウスオーバー (GanttBar)
+  → onHover(task) → GanttChart state更新
+  → GanttTooltip表示:
+    タイトル: "スキーマ定義"
+    Issue: #42
+    状態: completed
+    見積: 2h
+    依存: なし
+```
+
+### バークリック → Issue遷移フロー
+
+```
+クリック (GanttBar)
+  → onClick(task) → window.open(task.issueUrl, "_blank")
+  → GitHub IssueページがNewタブで開く
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **transformToGanttData**:
+  - P0のみ: 直列配置のstartOffset計算が正しいこと
+  - P0 + P1: P1のstartOffsetがP0合計時間と等しいこと
+  - P0 + P1 + P2: P2のstartOffsetがP1最長タスク終了後であること
+  - タスク0件: 空のグループが除外されること
+  - estimatedHoursが未設定: デフォルト値（DEFAULT_HOURS）が使用されること
+  - criticalPath指定: 該当タスクの `isCriticalPath` がtrueになること
+  - timelineEnd: 全タスクの最大終了時間が正しいこと
+- **Issue状態マッピング**:
+  - open → pending（デフォルト）
+  - open + assignees → in_progress
+  - closed → completed
+  - open + blocked dependency → blocked
+
+### コンポーネントテスト
+
+- **GanttBar**:
+  - 各状態での色が正しいこと
+  - バー幅が `estimatedHours * hourWidth` であること
+  - バー位置が `startOffset * hourWidth` であること
+  - ホバー時にonHoverが呼ばれること
+  - クリック時にonClickが呼ばれること
+- **GanttHeader**:
+  - timelineEndまでの目盛りが表示されること
+  - グリッド線の数が時間数と一致すること
+- **GanttLegend**:
+  - 4つの状態が全て表示されること
+- **GanttChart（統合）**:
+  - GanttDataに基づくSVG要素の数
+  - グループヘッダーの表示
+  - クリティカルパスハイライトの適用
+
+### 統合テスト
+
+- Specification詳細ページ内でのGanttチャート表示
+- implementationフィールドが未設定の場合の空状態表示
+- 複数グループを持つデータでのレイアウト検証
+
+## 6. 技術的決定事項
+
+### カスタムSVG実装（Rechartsではなく）
+
+**決定:** Ganttチャートはカスタムの SVGコンポーネントで実装し、Rechartsは使用しない
+**理由:** Rechartsは棒グラフ・折れ線グラフ等の汎用チャートに適しているが、Ganttチャートの要件（並列グループレイアウト、クリティカルパスオーバーレイ、バー内テキスト、依存関係矢印）は汎用チャートの範囲を超える。カスタムSVGにより、レイアウトの自由度が確保でき、追加の依存ライブラリも不要。SVG要素はReactコンポーネントとして自然に記述できる。
+
+### Server Component → Client Component分離
+
+**決定:** データ変換はServer Component側で完結させ、SVG描画のみをClient Componentで実行
+**理由:** `transformToGanttData` はファイルシステムから取得したSpecificationデータに依存するため、Server Component内で実行する。変換後のGanttDataオブジェクトはシリアライズ可能な純粋なデータであり、propsとしてClient Component（GanttChart）に渡す。これにより、クライアントバンドルにファイルI/Oロジックが含まれることを防ぐ。
+
+### P0直列・P1/P2並列のレイアウト方針
+
+**決定:** P0タスクは直列（順次）配置、P1/P2タスクは並列配置とする
+**理由:** spec-000016の分解戦略に従い、P0は基盤タスク（スキーマ定義等）で順次実行が必要、P1は並列可能な実装タスク、P2はオプションタスク。この優先度ベースのレイアウトにより、作業のスケジュール感が視覚的に伝わる。
+
+### Issue状態の4状態マッピング
+
+**決定:** GitHub APIの2状態（open/closed）をGanttチャート表示では4状態（completed / in_progress / blocked / pending）にマッピング
+**理由:** open状態を「依存先が未完了→blocked」「アサイン済み→in_progress」「それ以外→pending」に細分化することで、Ganttチャートの情報密度が向上する。ただし、初期実装ではspec-000024の同期データに基づく簡易マッピング（open→pending, closed→completed）を優先し、詳細な状態判定は段階的に追加する。

--- a/.reqord/specifications/spec-000026.json
+++ b/.reqord/specifications/spec-000026.json
@@ -1,0 +1,13 @@
+{
+  "id": "spec-000026",
+  "requirementId": "req-000022",
+  "version": "1.0.0",
+  "status": "draft",
+  "createdAt": "2026-02-08T14:08:15.325Z",
+  "updatedAt": "2026-02-08T14:08:15.325Z",
+  "versionHistory": [],
+  "files": {
+    "design": "specifications/spec-000026/design.md",
+    "supplementary": []
+  }
+}

--- a/.reqord/specifications/spec-000026/design.md
+++ b/.reqord/specifications/spec-000026/design.md
@@ -1,0 +1,638 @@
+# Web UI - 依存グラフ拡張・Spec詳細 - 技術設計書
+
+## 1. 設計概要
+
+spec-000023で実装されたRequirementレベルの依存関係グラフを、Requirement → Specification → Issue の3階層に拡張し、プロジェクト全体のトレーサビリティを可視化する。また、Specification詳細ページを新設し、タブ型UIでResearch / Design / Coverage / Issues / Historyの各データを表示する。Markdownコンテンツの表示にはReact Markdown + Mermaid.jsを使用し、設計文書内のダイアグラムをインライン表示する。
+
+## 2. アーキテクチャ
+
+```
+packages/web/src/
+  ├── app/
+  │   ├── graph/
+  │   │   └── page.tsx                        (既存: 拡張 - グラフモード切替追加)
+  │   └── specifications/
+  │       ├── page.tsx                         (新規: Specification一覧)
+  │       ├── loading.tsx                      (新規: ローディングUI)
+  │       └── [id]/
+  │           ├── page.tsx                     (新規: Specification詳細)
+  │           ├── loading.tsx                  (新規: ローディングUI)
+  │           └── not-found.tsx               (新規: 404ページ)
+  ├── components/
+  │   ├── graph/
+  │   │   ├── dependency-graph.tsx             (既存: 拡張 - 多階層ノード対応)
+  │   │   ├── requirement-node.tsx             (既存)
+  │   │   ├── specification-node.tsx           (新規: Specificationノード)
+  │   │   ├── issue-node.tsx                   (新規: Issueノード)
+  │   │   ├── dag-layout.ts                   (既存: 拡張 - 多階層対応)
+  │   │   ├── graph-loader.tsx                (既存)
+  │   │   ├── graph-mode-selector.tsx          (新規: グラフモード切替)
+  │   │   └── multi-level-graph.tsx            (新規: 多階層グラフコンポーネント)
+  │   ├── specification/                       (新規ディレクトリ)
+  │   │   ├── spec-detail.tsx                  (詳細表示メインコンポーネント)
+  │   │   ├── spec-tabs.tsx                    (タブコンテナ)
+  │   │   ├── tab-research.tsx                 (Researchタブ)
+  │   │   ├── tab-design.tsx                   (Designタブ)
+  │   │   ├── tab-coverage.tsx                 (Coverageタブ)
+  │   │   ├── tab-issues.tsx                   (Issuesタブ)
+  │   │   ├── tab-history.tsx                  (Historyタブ)
+  │   │   └── spec-table.tsx                   (一覧テーブル)
+  │   ├── markdown/                            (新規ディレクトリ)
+  │   │   ├── markdown-renderer.tsx            (React Markdownレンダラ)
+  │   │   └── mermaid-block.tsx                (Mermaidダイアグラムレンダラ)
+  │   └── ui/
+  │       ├── badge.tsx                        (既存)
+  │       ├── nav.tsx                          (既存: Specificationsリンク追加)
+  │       └── tabs.tsx                         (新規: タブUIコンポーネント)
+  └── lib/
+      ├── specification-repository.ts          (spec-000022で新規: Specification読み取り)
+      ├── specification-data.ts                (新規: Specificationデータ取得)
+      ├── graph-data.ts                        (新規: 多階層グラフデータ構築)
+      ├── data.ts                              (既存: Requirement読み取り)
+      └── local-repository.ts                  (既存: ファイルI/O)
+```
+
+### データアクセスの流れ
+
+```
+ブラウザ → /specifications/[id] (GET)
+  → SpecificationDetailPage (Server Component)
+    → getSpecificationById(id) → Specification JSON
+    → loadDesignFile(id) → design.md
+    → loadResearchFile(id) → research.md (存在する場合)
+    → getRequirementById(spec.requirementId) → Requirement JSON
+  → SpecDetail (Client Component)
+    → タブ切替 → 各タブコンポーネント描画
+
+ブラウザ → /graph (GET)
+  → GraphPage (Server Component)
+    → getAllRequirements() + getAllSpecifications()
+    → buildMultiLevelGraphData() → 多階層グラフデータ
+  → GraphLoader → MultiLevelGraph or DependencyGraph
+```
+
+## 3. コンポーネント設計
+
+### 3.1 ページコンポーネント
+
+#### Specification一覧ページ (`specifications/page.tsx` - 新規)
+
+- Server Componentとして全Specificationsを取得
+- `dynamic = "force-dynamic"` でキャッシュ無効化
+- `<SpecTable>` にデータを渡す
+- 関連Requirementのタイトルも表示（joinデータ取得）
+
+```typescript
+export default async function SpecificationsPage() {
+  const specifications = await getAllSpecifications();
+  const requirements = await getAllRequirements();
+
+  // RequirementタイトルのマッピングをSpecTableに渡す
+  const reqTitleMap = new Map(requirements.map(r => [r.id, r.title]));
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">Specifications</h1>
+      <SpecTable specifications={specifications} requirementTitles={reqTitleMap} />
+    </div>
+  );
+}
+```
+
+#### Specification詳細ページ (`specifications/[id]/page.tsx` - 新規)
+
+- `generateMetadata` で動的タイトル生成
+- 並列データ取得: Specification JSON + design.md + research.md + Requirement
+- Specificationが存在しない場合は `notFound()` を呼び出し
+- `<SpecDetail>` コンポーネントに全データを委譲
+
+```typescript
+export default async function SpecificationDetailPage({
+  params,
+}: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const [specification, design, research, requirement] = await Promise.all([
+    getSpecificationById(id),
+    loadSpecFile(id, "design.md"),
+    loadSpecFile(id, "research.md"),
+    // requirementIdはspec取得後に解決するため、ここでは全req取得
+    getAllRequirements(),
+  ]);
+
+  if (!specification) notFound();
+
+  const req = requirement.find(r => r.id === specification.requirementId);
+
+  return (
+    <SpecDetail
+      specification={specification}
+      design={design}
+      research={research}
+      requirement={req ?? null}
+    />
+  );
+}
+```
+
+#### グラフページ拡張 (`graph/page.tsx` - 既存拡張)
+
+- グラフモード切替UI追加: "Requirements Only" / "Full Traceability"
+- "Full Traceability" モード時は Requirement + Specification + Issue ノードを表示
+- 追加データ取得: `getAllSpecifications()`
+
+### 3.2 Specification詳細コンポーネント
+
+#### SpecDetail (`components/specification/spec-detail.tsx` - 新規)
+
+**責務:** Specification詳細表示のメインコンポーネント。
+
+```typescript
+"use client";
+
+interface SpecDetailProps {
+  specification: Specification;
+  design: string | null;
+  research: string | null;
+  requirement: Requirement | null;
+}
+```
+
+- ヘッダー: ID、ステータスバッジ、バージョン、関連Requirement名
+- タブコンテナ: `<SpecTabs>` で各タブを管理
+
+#### SpecTabs (`components/specification/spec-tabs.tsx` - 新規)
+
+**責務:** タブの切替とコンテンツの表示。
+
+```typescript
+"use client";
+
+interface SpecTabsProps {
+  tabs: TabConfig[];
+  defaultTab?: string;
+}
+
+interface TabConfig {
+  id: string;
+  label: string;
+  content: React.ReactNode;
+  badge?: string;            // タブラベル横のバッジ（件数等）
+  disabled?: boolean;
+}
+```
+
+- `useState` でアクティブタブを管理
+- URLハッシュとの同期（`#design`, `#issues` 等）
+- タブ変更時のスムーズな切替（アニメーションなし、即時切替）
+
+#### TabResearch (`components/specification/tab-research.tsx` - 新規)
+
+**責務:** research.md の内容をMarkdownレンダリング。
+
+```typescript
+interface TabResearchProps {
+  content: string | null;
+}
+```
+
+- `<MarkdownRenderer>` コンポーネントにコンテンツを渡す
+- research.mdが存在しない場合は「Research document not available」表示
+
+#### TabDesign (`components/specification/tab-design.tsx` - 新規)
+
+**責務:** design.md の内容をMarkdownレンダリング + Mermaidダイアグラム対応。
+
+```typescript
+interface TabDesignProps {
+  content: string | null;
+}
+```
+
+- `<MarkdownRenderer>` でMarkdown表示
+- コードブロック中の `mermaid` 言語指定を検出し、`<MermaidBlock>` で描画
+
+#### TabCoverage (`components/specification/tab-coverage.tsx` - 新規)
+
+**責務:** 成功基準のカバレッジテーブル表示。
+
+```typescript
+interface TabCoverageProps {
+  requirement: Requirement | null;
+  specification: Specification;
+}
+```
+
+- 関連Requirementの `successCriteria` 一覧
+- 各基準のカバー状態（将来的にはspec内のcoverageフィールドから取得、初期は全て「未確認」）
+- テーブル表示: 基準テキスト / カバー状態 / 備考
+
+#### TabIssues (`components/specification/tab-issues.tsx` - 新規)
+
+**責務:** GitHub Issueリストとガントチャート表示。
+
+```typescript
+interface TabIssuesProps {
+  specification: Specification;
+}
+```
+
+- Issueリストテーブル: Issue番号、タイトル、状態、優先度、GitHub URL
+- spec-000025のGanttチャートをインライン表示
+- `implementation` フィールドが未設定の場合は「No issues generated yet」表示
+
+#### TabHistory (`components/specification/tab-history.tsx` - 新規)
+
+**責務:** バージョン履歴のタイムライン表示。
+
+```typescript
+interface TabHistoryProps {
+  versionHistory: VersionHistoryEntry[];
+  currentVersion: string;
+}
+```
+
+- 縦方向のタイムライン表示
+- 各エントリ: バージョン番号、ステータス変更、gitコミットハッシュ、承認者、日時
+- 最新バージョンにハイライト
+- Tailwind CSSによるタイムラインUI（`border-l-2` + ドット）
+
+### 3.3 多階層グラフコンポーネント
+
+#### MultiLevelGraph (`components/graph/multi-level-graph.tsx` - 新規)
+
+**責務:** Requirement → Specification → Issue の3階層グラフ描画。
+
+```typescript
+"use client";
+
+interface MultiLevelGraphProps {
+  graphData: MultiLevelGraphData;
+}
+
+interface MultiLevelGraphData {
+  nodes: MultiLevelNode[];
+  edges: MultiLevelEdge[];
+}
+
+interface MultiLevelNode {
+  id: string;
+  type: "requirement" | "specification" | "issue";
+  data: {
+    label: string;
+    status: string;
+    priority?: string;
+    issueNumber?: number;
+    issueUrl?: string;
+  };
+  position: { x: number; y: number };
+}
+
+interface MultiLevelEdge {
+  id: string;
+  source: string;
+  target: string;
+  type: "dependency" | "implements" | "tracks";  // 関係の種類
+}
+```
+
+- React Flowベース（DependencyGraphと同じ基盤）
+- ノードタイプ別の描画: requirement / specification / issue
+- エッジタイプ別のスタイル:
+  - `dependency`: 実線矢印（Requirement間のblockedBy）
+  - `implements`: 破線矢印（Specification → Requirement）
+  - `tracks`: 点線矢印（Issue → Specification）
+
+#### SpecificationNode (`components/graph/specification-node.tsx` - 新規)
+
+**責務:** Specificationノードの描画。
+
+```typescript
+"use client";
+
+const SPEC_STATUS_COLORS: Record<string, string> = {
+  draft: "border-blue-300 bg-blue-50",
+  pending_approval: "border-purple-300 bg-purple-50",
+  approved: "border-green-300 bg-green-50",
+  deprecated: "border-red-300 bg-red-50",
+};
+```
+
+- RequirementNodeとは異なる色テーマ（青系）でSpecificationを区別
+- クリックで `/specifications/{id}` へ遷移
+- ノード幅: 200px
+
+#### IssueNode (`components/graph/issue-node.tsx` - 新規)
+
+**責務:** GitHub Issueノードの描画。
+
+```typescript
+"use client";
+
+const ISSUE_STATE_COLORS: Record<string, string> = {
+  open: "border-yellow-300 bg-yellow-50",
+  in_progress: "border-blue-300 bg-blue-50",
+  closed: "border-green-300 bg-green-50",
+};
+```
+
+- Issue番号とタイトルを表示
+- クリックでGitHub Issue URLを新規タブで開く
+- ノード幅: 180px（コンパクト表示）
+
+#### GraphModeSelector (`components/graph/graph-mode-selector.tsx` - 新規)
+
+**責務:** グラフモードの切替UI。
+
+```typescript
+"use client";
+
+interface GraphModeSelectorProps {
+  mode: "requirements" | "traceability";
+  onModeChange: (mode: "requirements" | "traceability") => void;
+}
+```
+
+- セグメンテッドコントロール（2択トグル）
+- "Requirements Only": 既存のRequirement依存関係グラフ
+- "Full Traceability": Requirement → Specification → Issue の3階層グラフ
+
+### 3.4 Markdownレンダラ
+
+#### MarkdownRenderer (`components/markdown/markdown-renderer.tsx` - 新規)
+
+**責務:** Markdownコンテンツの安全なHTML変換と表示。
+
+```typescript
+"use client";
+
+interface MarkdownRendererProps {
+  content: string;
+  className?: string;
+}
+```
+
+- `react-markdown` ライブラリによるMarkdown → React変換
+- `remark-gfm` プラグインでGitHub Flavored Markdownサポート（テーブル、タスクリスト、打ち消し線）
+- カスタムコンポーネントマッピング:
+  - `code` ブロック: 言語が `mermaid` の場合は `<MermaidBlock>` に委譲
+  - `a` タグ: 外部リンクには `target="_blank"` と `rel="noopener noreferrer"` を付与
+  - `table`: Tailwind CSSのテーブルスタイル適用
+- Tailwind CSS Typographyプラグインによるproseスタイル
+
+#### MermaidBlock (`components/markdown/mermaid-block.tsx` - 新規)
+
+**責務:** Mermaid.jsによるダイアグラムのクライアントサイドレンダリング。
+
+```typescript
+"use client";
+
+interface MermaidBlockProps {
+  chart: string;       // Mermaid記法の文字列
+  className?: string;
+}
+```
+
+- `mermaid.render()` によるSVG生成
+- `useEffect` 内でMermaid APIを呼び出し（クライアントサイドのみ）
+- レンダリング結果を `dangerouslySetInnerHTML` で表示
+- パースエラー時はフォールバック（元のコードブロックとして表示）
+- Mermaid.js初期化: `mermaid.initialize({ startOnLoad: false, theme: "default" })`
+
+### 3.5 データ層
+
+#### specification-data.ts (`lib/specification-data.ts` - 新規)
+
+**責務:** Specificationデータの取得と関連ファイルの読み込み。
+
+```typescript
+export async function getAllSpecifications(): Promise<Specification[]>;
+export async function getSpecificationById(id: string): Promise<Specification | null>;
+export async function loadSpecFile(id: string, filename: string): Promise<string | null>;
+```
+
+- spec-000022で作成される `specification-repository.ts` を利用
+- ファイル読み込みは `REQORD_ROOT` 環境変数ベースのディレクトリ解決
+
+#### graph-data.ts (`lib/graph-data.ts` - 新規)
+
+**責務:** 多階層グラフデータの構築。
+
+```typescript
+export function buildMultiLevelGraphData(
+  requirements: Requirement[],
+  specifications: Specification[],
+): MultiLevelGraphData;
+```
+
+**構築ロジック:**
+
+```typescript
+function buildMultiLevelGraphData(
+  requirements: Requirement[],
+  specifications: Specification[],
+): MultiLevelGraphData {
+  const nodes: MultiLevelNode[] = [];
+  const edges: MultiLevelEdge[] = [];
+
+  // 1. Requirementノードを配置（左列）
+  requirements.forEach((req, i) => {
+    nodes.push({
+      id: req.id,
+      type: "requirement",
+      data: { label: req.title, status: req.status, priority: req.priority },
+      position: { x: 0, y: i * 120 },
+    });
+    // Requirement間の依存エッジ
+    req.dependencies.blockedBy.forEach(depId => {
+      edges.push({
+        id: `dep-${depId}-${req.id}`,
+        source: depId,
+        target: req.id,
+        type: "dependency",
+      });
+    });
+  });
+
+  // 2. Specificationノードを配置（中央列）
+  specifications.forEach((spec, i) => {
+    nodes.push({
+      id: spec.id,
+      type: "specification",
+      data: { label: spec.id, status: spec.status },
+      position: { x: 400, y: i * 120 },
+    });
+    // Specification → Requirement の implements エッジ
+    edges.push({
+      id: `impl-${spec.id}-${spec.requirementId}`,
+      source: spec.id,
+      target: spec.requirementId,
+      type: "implements",
+    });
+
+    // 3. Issueノードを配置（右列）
+    if (spec.implementation?.issues) {
+      spec.implementation.issues.forEach((issue, j) => {
+        const issueId = `issue-${issue.number}`;
+        nodes.push({
+          id: issueId,
+          type: "issue",
+          data: {
+            label: issue.title,
+            status: issue.status,
+            issueNumber: issue.number,
+            issueUrl: issue.url,
+          },
+          position: { x: 800, y: i * 120 + j * 80 },
+        });
+        // Issue → Specification の tracks エッジ
+        edges.push({
+          id: `track-${issueId}-${spec.id}`,
+          source: issueId,
+          target: spec.id,
+          type: "tracks",
+        });
+      });
+    }
+  });
+
+  return { nodes, edges };
+}
+```
+
+### 3.6 ナビゲーション更新
+
+既存の `components/ui/nav.tsx` にSpecificationsリンクを追加:
+
+```typescript
+const navItems = [
+  { href: "/dashboard", label: "ダッシュボード" },    // spec-000022で追加
+  { href: "/requirements", label: "要件一覧" },
+  { href: "/specifications", label: "仕様一覧" },     // 新規追加
+  { href: "/graph", label: "依存関係グラフ" },
+];
+```
+
+## 4. データフロー
+
+### Specification詳細表示フロー
+
+```
+ブラウザ → /specifications/spec-000016 (GET)
+  → SpecificationDetailPage (Server Component)
+    → Promise.all([
+        getSpecificationById("spec-000016"),  → Specification JSON
+        loadSpecFile("spec-000016", "design.md"),  → design.md内容
+        loadSpecFile("spec-000016", "research.md"),  → research.md内容（nullの場合あり）
+        getAllRequirements(),  → Requirement[] (requirementIdの解決用)
+      ])
+    → <SpecDetail specification={...} design={...} research={...} requirement={...} />
+  → HTML + propsのシリアライゼーション
+
+ブラウザ (CSR)
+  → SpecDetail (Client Component)
+    → ヘッダー描画: ID, ステータス, バージョン
+    → <SpecTabs>
+      → デフォルトタブ: "Design"
+      → タブクリック → アクティブタブ切替
+      → <TabDesign content={design} />
+        → <MarkdownRenderer content={design} />
+          → react-markdown → HTML変換
+          → Mermaidコードブロック検出 → <MermaidBlock>
+            → mermaid.render() → SVG表示
+```
+
+### 多階層グラフ表示フロー
+
+```
+ブラウザ → /graph (GET)
+  → GraphPage (Server Component)
+    → getAllRequirements() + getAllSpecifications()
+    → 両データをGraphLoaderに渡す
+  → HTML + データのシリアライゼーション
+
+ブラウザ (CSR)
+  → GraphLoader → GraphModeSelector表示
+    → "Requirements Only" 選択時:
+      → DependencyGraph (既存)
+    → "Full Traceability" 選択時:
+      → buildMultiLevelGraphData(requirements, specifications)
+      → MultiLevelGraph
+        → React Flow描画:
+          → RequirementNode (左列)
+          → SpecificationNode (中央列)
+          → IssueNode (右列)
+          → dependency / implements / tracks エッジ
+```
+
+### ノードクリック → 詳細遷移フロー
+
+```
+RequirementNode クリック → /requirements/{id}
+SpecificationNode クリック → /specifications/{id}
+IssueNode クリック → window.open(issueUrl, "_blank") → GitHub Issue
+```
+
+## 5. テスト方針
+
+### ユニットテスト
+
+- **buildMultiLevelGraphData**:
+  - Requirementのみ: Specificationノードなし
+  - Requirement + Specification: implementsエッジが正しいこと
+  - Requirement + Specification + Issue: 3階層のノードとエッジ
+  - 存在しないrequirementIdへの参照: エッジが無視されること
+  - implementationフィールドなし: Issueノードが生成されないこと
+- **loadSpecFile**:
+  - ファイルが存在する場合: コンテンツが返されること
+  - ファイルが存在しない場合: nullが返されること
+- **MarkdownRenderer内部ロジック**:
+  - Mermaidコードブロックの検出
+  - 外部リンクへのtarget="_blank"付与
+  - GFMテーブルのレンダリング
+
+### コンポーネントテスト
+
+- **SpecTable**: Specificationリストの行数・カラム値
+- **SpecTabs**: タブ切替でアクティブタブが変わること
+- **TabDesign**: Markdownコンテンツの描画
+- **TabCoverage**: 成功基準テーブルの行数
+- **TabIssues**: Issueリストテーブルの行数、implementationなし時の空状態
+- **TabHistory**: バージョン履歴エントリの表示
+- **SpecificationNode**: ステータス別の色クラスが適用されること
+- **IssueNode**: 状態別の色クラスが適用されること
+- **GraphModeSelector**: モード切替時にonModeChangeが呼ばれること
+- **MermaidBlock**: レンダリングエラー時のフォールバック表示
+
+### 統合テスト
+
+- Specification詳細ページ: 全タブの切替と表示
+- 多階層グラフ: RequirementとSpecificationの接続が正しいこと
+- グラフモード切替: RequirentsOnly → Traceabilityの切替
+- CLIで作成したSpecificationがWeb UIに表示されること
+
+## 6. 技術的決定事項
+
+### react-markdown + remark-gfmの採用
+
+**決定:** Markdownレンダリングに `react-markdown` + `remark-gfm` を使用
+**理由:** Reactコンポーネントとして自然に統合でき、カスタムコンポーネントマッピング（Mermaidブロック等）が容易。`remark-gfm` によりGitHub Flavored Markdown（テーブル、タスクリスト）をサポートし、設計文書の表現力を確保する。`dangerouslySetInnerHTML` を使わずにMarkdownを安全にレンダリング可能（Mermaidのみ例外）。
+
+### Mermaid.jsのクライアントサイドレンダリング
+
+**決定:** MermaidダイアグラムはClient Component内で `mermaid.render()` を使用してレンダリング
+**理由:** Mermaid.jsはDOM操作を必要とするため、Server Component内では実行不可。`useEffect` フック内でMermaid APIを呼び出し、生成されたSVGをDOMに挿入する。パースエラー時のフォールバック（元のコードブロック表示）により、不正なMermaid記法でもページが壊れない。
+
+### タブUIのクライアントサイド実装
+
+**決定:** タブ切替はClient Component（`useState`）で実装し、URLハッシュとの同期を行う
+**理由:** タブ切替は瞬時に行われるべきで、各タブ切替でサーバーリクエストを発行するのは遅すぎる。全タブのデータをServer Componentで事前取得し、Client Component側でタブの表示/非表示を切り替える。URLハッシュ同期（`#design`, `#issues`）により、直接リンクでの特定タブ表示やブラウザの戻る/進む操作をサポート。
+
+### 多階層グラフのレイアウト方式
+
+**決定:** Requirement（左列）→ Specification（中央列）→ Issue（右列）の3列レイアウト
+**理由:** トレーサビリティの階層構造を左→右の方向で直感的に表現。spec-000023の既存DAGレイアウトを拡張し、エンティティタイプごとにx座標のオフセットを固定する。React Flowのauto-layoutではなくカスタム座標計算により、各列の整列を保証する。
+
+### エッジタイプの視覚的区別
+
+**決定:** 3種類のエッジを線のスタイルで区別する（実線 / 破線 / 点線）
+**理由:** dependency（Requirement間）、implements（Specification → Requirement）、tracks（Issue → Specification）の3種類の関係を色だけでなく線種で区別することで、色覚に依存しないアクセシブルな表現を実現。凡例とあわせて各エッジの意味をユーザーに明示する。


### PR DESCRIPTION
## Summary

全22件のrequirementsに対して26件のspecificationを作成し、各specificationに詳細な技術設計書（design.md）を日本語で記述しました。

## Changes

### Specifications Created (26件)

**1 spec per requirement (19件):**
- spec-000001 ~ spec-000005: CLI基本機能・Context・共有型・バージョン管理
- spec-000006: AI最適化
- spec-000008 ~ spec-000015: CRUD拡張・エラー処理・承認フロー・影響分析
- spec-000017 ~ spec-000021: Gap分析・実装検証・ステータス表示・LLMコンテキスト・EARS変換

**2 specs per requirement (4件):**
- req-000007 → spec-000007 (要件管理画面), spec-000023 (依存関係グラフ)
- req-000016 → spec-000016 (Issue生成), spec-000024 (Issue同期・進捗追跡)

**3 specs per requirement (3件):**
- req-000022 → spec-000022 (ダッシュボード), spec-000025 (Ganttチャート), spec-000026 (依存グラフ拡張・Spec詳細)

### Design Documentation (6,745行)

各design.mdは統一された6セクション構成:
1. **設計概要** - 技術的アプローチの概要
2. **アーキテクチャ** - コンポーネント構成、レイヤー配置
3. **コンポーネント設計** - 主要モジュールのインターフェース・責務
4. **データフロー** - 処理の流れ
5. **テスト方針** - ユニットテスト・統合テストの方針
6. **技術的決定事項** - 選択したアプローチとその理由

### Key Files

- `spec-000001/design.md` (73行): CLI初期化コマンド
- `spec-000002/design.md` (132行): Requirement CRUD
- `spec-000013/design.md` (183行): Specification CRUD
- `spec-000016/design.md` (345行): GitHub Issue生成（AI分解）
- `spec-000022/design.md` (421行): Web UI ダッシュボード
- `spec-000026/design.md` (638行): Web UI 依存グラフ拡張・Spec詳細

## Testing

```bash
# Verification commands
node packages/cli/dist/index.js spec list
# → 26 specification(s) found.

node packages/cli/dist/index.js spec show spec-000001
node packages/cli/dist/index.js spec show spec-000016
node packages/cli/dist/index.js spec show spec-000026

# All design.md files have substantial content (no default templates)
rg "Phase 3で実装予定" .reqord/specifications/*/design.md
# → No matches (except as reference text in spec-000015)
```

## Related

- Based on requirements: req-000001 ~ req-000022
- Follows structure from: docs/main.md
- Uses existing implementations: packages/cli/src/, packages/shared/src/, packages/web/src/

🤖 Generated with [Claude Code](https://claude.com/claude-code)