### PR TITLE
feat: Specification Web UI (read-only)

### DIFF
--- a/packages/web/src/__tests__/lib/local-specification-repository.test.ts
+++ b/packages/web/src/__tests__/lib/local-specification-repository.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function makeSpecJson(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    id: "spec-000001",
+    requirementId: "req-000001",
+    version: "1.0.0",
+    status: "draft",
+    createdAt: "2026-02-08T14:07:39.737Z",
+    updatedAt: "2026-02-08T14:07:54.055Z",
+    versionHistory: [],
+    files: {
+      design: "specifications/spec-000001/design.md",
+      supplementary: [],
+    },
+    ...overrides,
+  });
+}
+
+describe("LocalSpecificationRepository", () => {
+  let tmpDir: string;
+  let specDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "reqord-spec-test-"));
+    specDir = join(tmpDir, ".reqord", "specifications");
+    await mkdir(specDir, { recursive: true });
+    process.env.REQORD_ROOT = tmpDir;
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    delete process.env.REQORD_ROOT;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function getRepo() {
+    const { LocalSpecificationRepository } = await import(
+      "../../lib/local-specification-repository"
+    );
+    return new LocalSpecificationRepository();
+  }
+
+  describe("findAll", () => {
+    it("returns all valid specification files sorted by ID", async () => {
+      await writeFile(
+        join(specDir, "spec-000002.json"),
+        makeSpecJson({ id: "spec-000002", requirementId: "req-000002" }),
+      );
+      await writeFile(
+        join(specDir, "spec-000001.json"),
+        makeSpecJson({ id: "spec-000001", requirementId: "req-000001" }),
+      );
+
+      const repo = await getRepo();
+      const specs = await repo.findAll();
+
+      expect(specs).toHaveLength(2);
+      expect(specs[0].id).toBe("spec-000001");
+      expect(specs[1].id).toBe("spec-000002");
+    });
+
+    it("skips invalid JSON files", async () => {
+      await writeFile(
+        join(specDir, "spec-000001.json"),
+        makeSpecJson({ id: "spec-000001" }),
+      );
+      await writeFile(join(specDir, "spec-000002.json"), "{ invalid json }");
+
+      const repo = await getRepo();
+      const specs = await repo.findAll();
+
+      expect(specs).toHaveLength(1);
+      expect(specs[0].id).toBe("spec-000001");
+    });
+
+    it("skips files not matching spec-NNNNNN.json pattern", async () => {
+      await writeFile(
+        join(specDir, "spec-000001.json"),
+        makeSpecJson({ id: "spec-000001" }),
+      );
+      await writeFile(join(specDir, "notes.txt"), "not a spec");
+
+      const repo = await getRepo();
+      const specs = await repo.findAll();
+
+      expect(specs).toHaveLength(1);
+    });
+
+    it("returns empty array when directory has no files", async () => {
+      const repo = await getRepo();
+      const specs = await repo.findAll();
+
+      expect(specs).toEqual([]);
+    });
+  });
+
+  describe("findById", () => {
+    it("returns a specification when it exists", async () => {
+      await writeFile(
+        join(specDir, "spec-000001.json"),
+        makeSpecJson({ id: "spec-000001" }),
+      );
+
+      const repo = await getRepo();
+      const spec = await repo.findById("spec-000001");
+
+      expect(spec).not.toBeNull();
+      expect(spec!.id).toBe("spec-000001");
+      expect(spec!.requirementId).toBe("req-000001");
+    });
+
+    it("returns null when specification does not exist", async () => {
+      const repo = await getRepo();
+      const spec = await repo.findById("spec-999999");
+
+      expect(spec).toBeNull();
+    });
+
+    it("throws on invalid specification data", async () => {
+      await writeFile(
+        join(specDir, "spec-000001.json"),
+        JSON.stringify({ id: "spec-000001" }),
+      );
+
+      const repo = await getRepo();
+      await expect(repo.findById("spec-000001")).rejects.toThrow(
+        "Invalid specification",
+      );
+    });
+  });
+
+  describe("loadDesign", () => {
+    it("returns design content when design.md exists", async () => {
+      const designDir = join(specDir, "spec-000001");
+      await mkdir(designDir, { recursive: true });
+      await writeFile(join(designDir, "design.md"), "# Design\n\nSome content");
+
+      const repo = await getRepo();
+      const design = await repo.loadDesign("spec-000001");
+
+      expect(design).toBe("# Design\n\nSome content");
+    });
+
+    it("returns null when design.md does not exist", async () => {
+      const repo = await getRepo();
+      const design = await repo.loadDesign("spec-999999");
+
+      expect(design).toBeNull();
+    });
+  });
+
+  describe("findByRequirementId", () => {
+    it("returns specifications matching the requirement ID", async () => {
+      await writeFile(
+        join(specDir, "spec-000001.json"),
+        makeSpecJson({ id: "spec-000001", requirementId: "req-000001" }),
+      );
+      await writeFile(
+        join(specDir, "spec-000002.json"),
+        makeSpecJson({ id: "spec-000002", requirementId: "req-000002" }),
+      );
+      await writeFile(
+        join(specDir, "spec-000003.json"),
+        makeSpecJson({ id: "spec-000003", requirementId: "req-000001" }),
+      );
+
+      const repo = await getRepo();
+      const specs = await repo.findByRequirementId("req-000001");
+
+      expect(specs).toHaveLength(2);
+      expect(specs.map((s) => s.id)).toEqual(["spec-000001", "spec-000003"]);
+    });
+
+    it("returns empty array when no specifications match", async () => {
+      await writeFile(
+        join(specDir, "spec-000001.json"),
+        makeSpecJson({ id: "spec-000001", requirementId: "req-000001" }),
+      );
+
+      const repo = await getRepo();
+      const specs = await repo.findByRequirementId("req-999999");
+
+      expect(specs).toEqual([]);
+    });
+  });
+});

--- a/packages/web/src/app/graph/page.tsx
+++ b/packages/web/src/app/graph/page.tsx
@@ -1,4 +1,5 @@
 import { getAllRequirements } from "@/lib/data";
+import { getAllSpecifications } from "@/lib/specification-data";
 import { GraphLoader } from "@/components/graph/graph-loader";
 
 export const metadata = {
@@ -8,12 +9,20 @@ export const metadata = {
 export const dynamic = "force-dynamic";
 
 export default async function GraphPage() {
-  const requirements = await getAllRequirements();
+  const [requirements, specifications] = await Promise.all([
+    getAllRequirements(),
+    getAllSpecifications(),
+  ]);
+
+  const specCountMap: Record<string, number> = {};
+  for (const spec of specifications) {
+    specCountMap[spec.requirementId] = (specCountMap[spec.requirementId] ?? 0) + 1;
+  }
 
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold">Dependency Graph</h1>
-      <GraphLoader requirements={requirements} />
+      <GraphLoader requirements={requirements} specCountMap={specCountMap} />
     </div>
   );
 }

--- a/packages/web/src/app/requirements/[id]/page.tsx
+++ b/packages/web/src/app/requirements/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { getRequirementById, getRequirementDescription } from "@/lib/data";
+import { getSpecificationsByRequirementId } from "@/lib/specification-data";
 import { RequirementDetail } from "@/components/requirement/requirement-detail";
 
 export const dynamic = "force-dynamic";
@@ -19,14 +20,21 @@ export default async function RequirementPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const [requirement, description] = await Promise.all([
+  const [requirement, description, specifications] = await Promise.all([
     getRequirementById(id),
     getRequirementDescription(id),
+    getSpecificationsByRequirementId(id),
   ]);
 
   if (!requirement) {
     notFound();
   }
 
-  return <RequirementDetail requirement={requirement} description={description} />;
+  return (
+    <RequirementDetail
+      requirement={requirement}
+      description={description}
+      specifications={specifications}
+    />
+  );
 }

--- a/packages/web/src/app/specifications/[id]/loading.tsx
+++ b/packages/web/src/app/specifications/[id]/loading.tsx
@@ -1,0 +1,14 @@
+export default function Loading() {
+  return (
+    <div className="animate-pulse space-y-4">
+      <div className="h-6 w-32 rounded bg-gray-200" />
+      <div className="h-8 w-96 rounded bg-gray-200" />
+      <div className="flex gap-2">
+        <div className="h-6 w-16 rounded-full bg-gray-200" />
+        <div className="h-6 w-16 rounded-full bg-gray-200" />
+      </div>
+      <div className="h-24 w-full rounded bg-gray-200" />
+      <div className="h-48 w-full rounded bg-gray-200" />
+    </div>
+  );
+}

--- a/packages/web/src/app/specifications/[id]/not-found.tsx
+++ b/packages/web/src/app/specifications/[id]/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <h2 className="text-2xl font-bold text-gray-900">Specification Not Found</h2>
+      <p className="mt-2 text-gray-600">
+        The specification you&apos;re looking for does not exist.
+      </p>
+      <Link
+        href="/specifications"
+        className="mt-4 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+      >
+        Back to Specifications
+      </Link>
+    </div>
+  );
+}

--- a/packages/web/src/app/specifications/[id]/page.tsx
+++ b/packages/web/src/app/specifications/[id]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+import { getSpecificationById, getSpecificationDesign } from "@/lib/specification-data";
+import { getRequirementById } from "@/lib/data";
+import { SpecificationDetail } from "@/components/specification/specification-detail";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const specification = await getSpecificationById(id);
+  if (!specification) {
+    return { title: "Not Found - Reqord" };
+  }
+  return { title: `${specification.id} - Reqord` };
+}
+
+export default async function SpecificationPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const [specification, design] = await Promise.all([
+    getSpecificationById(id),
+    getSpecificationDesign(id),
+  ]);
+
+  if (!specification) {
+    notFound();
+  }
+
+  const requirement = await getRequirementById(specification.requirementId);
+
+  return (
+    <SpecificationDetail
+      specification={specification}
+      design={design}
+      requirementTitle={requirement?.title ?? null}
+    />
+  );
+}

--- a/packages/web/src/app/specifications/loading.tsx
+++ b/packages/web/src/app/specifications/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <div className="animate-pulse space-y-4">
+      <div className="h-8 w-48 rounded bg-gray-200" />
+      <div className="h-10 w-full rounded bg-gray-200" />
+      <div className="space-y-2">
+        {Array.from({ length: 8 }, (_, i) => (
+          <div key={i} className="h-12 w-full rounded bg-gray-200" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/specifications/page.tsx
+++ b/packages/web/src/app/specifications/page.tsx
@@ -1,0 +1,42 @@
+import { Suspense } from "react";
+import { getAllSpecifications } from "@/lib/specification-data";
+import { getAllRequirements } from "@/lib/data";
+import { SpecificationTable } from "@/components/specification/specification-table";
+import Loading from "./loading";
+
+export const metadata = {
+  title: "Specifications - Reqord",
+};
+
+export const dynamic = "force-dynamic";
+
+async function SpecificationList() {
+  const [specifications, requirements] = await Promise.all([
+    getAllSpecifications(),
+    getAllRequirements(),
+  ]);
+
+  const requirementMap = Object.fromEntries(
+    requirements.map((r) => [r.id, r.title]),
+  );
+
+  return (
+    <SpecificationTable
+      specifications={specifications}
+      requirementTitleMap={requirementMap}
+    />
+  );
+}
+
+export default function SpecificationsPage() {
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">Specifications</h1>
+      </div>
+      <Suspense fallback={<Loading />}>
+        <SpecificationList />
+      </Suspense>
+    </div>
+  );
+}

--- a/packages/web/src/components/graph/dependency-graph.tsx
+++ b/packages/web/src/components/graph/dependency-graph.tsx
@@ -18,7 +18,13 @@ import { RequirementNode } from "./requirement-node";
 
 const nodeTypes = { requirement: RequirementNode };
 
-export function DependencyGraph({ requirements }: { requirements: Requirement[] }) {
+export function DependencyGraph({
+  requirements,
+  specCountMap = {},
+}: {
+  requirements: Requirement[];
+  specCountMap?: Record<string, number>;
+}) {
   const { initialNodes, initialEdges } = useMemo(() => {
     const { nodes: layoutNodes, edges: layoutEdges } = computeDagLayout(requirements);
 
@@ -26,7 +32,12 @@ export function DependencyGraph({ requirements }: { requirements: Requirement[] 
       id: n.id,
       type: "requirement",
       position: { x: n.x, y: n.y },
-      data: { label: n.title, status: n.status, priority: n.priority },
+      data: {
+        label: n.title,
+        status: n.status,
+        priority: n.priority,
+        specCount: specCountMap[n.id] ?? 0,
+      },
     }));
 
     const rfEdges: Edge[] = layoutEdges.map((e) => ({
@@ -39,7 +50,7 @@ export function DependencyGraph({ requirements }: { requirements: Requirement[] 
     }));
 
     return { initialNodes: rfNodes, initialEdges: rfEdges };
-  }, [requirements]);
+  }, [requirements, specCountMap]);
 
   const [nodes, , onNodesChange] = useNodesState(initialNodes);
   const [edges, , onEdgesChange] = useEdgesState(initialEdges);

--- a/packages/web/src/components/graph/graph-loader.tsx
+++ b/packages/web/src/components/graph/graph-loader.tsx
@@ -14,6 +14,12 @@ const DependencyGraph = dynamic(
   },
 );
 
-export function GraphLoader({ requirements }: { requirements: Requirement[] }) {
-  return <DependencyGraph requirements={requirements} />;
+export function GraphLoader({
+  requirements,
+  specCountMap = {},
+}: {
+  requirements: Requirement[];
+  specCountMap?: Record<string, number>;
+}) {
+  return <DependencyGraph requirements={requirements} specCountMap={specCountMap} />;
 }

--- a/packages/web/src/components/graph/requirement-node.tsx
+++ b/packages/web/src/components/graph/requirement-node.tsx
@@ -15,6 +15,7 @@ type RequirementNodeData = {
   label: string;
   status: string;
   priority: string;
+  specCount?: number;
 };
 
 function RequirementNodeComponent({ data, id }: NodeProps) {
@@ -33,6 +34,11 @@ function RequirementNodeComponent({ data, id }: NodeProps) {
           {nodeData.label}
         </p>
       </Link>
+      {nodeData.specCount && nodeData.specCount > 0 ? (
+        <p className="mt-1 text-xs text-gray-400">
+          📄 {nodeData.specCount} spec{nodeData.specCount > 1 ? "s" : ""}
+        </p>
+      ) : null}
       <Handle type="source" position={Position.Right} className="!bg-gray-400" />
     </div>
   );

--- a/packages/web/src/components/requirement/requirement-detail.tsx
+++ b/packages/web/src/components/requirement/requirement-detail.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import type { Requirement } from "@reqord/shared";
+import type { Requirement, Specification } from "@reqord/shared";
 import { StatusBadge, PriorityBadge, ComplexityBadge } from "@/components/ui/badge";
 import { MarkdownRenderer } from "./markdown-renderer";
 import { DeleteButton } from "./delete-button";
@@ -7,9 +7,11 @@ import { DeleteButton } from "./delete-button";
 export function RequirementDetail({
   requirement,
   description,
+  specifications = [],
 }: {
   requirement: Requirement;
   description: string | null;
+  specifications?: Specification[];
 }) {
   const { dependencies } = requirement;
   const hasDeps =
@@ -197,6 +199,28 @@ export function RequirementDetail({
           </div>
         </div>
       ) : null}
+
+      {/* Specifications */}
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <h2 className="mb-2 text-sm font-semibold text-gray-700">Specifications</h2>
+        {specifications.length > 0 ? (
+          <div className="space-y-1 text-sm">
+            {specifications.map((spec) => (
+              <div key={spec.id} className="flex items-center gap-2">
+                <Link
+                  href={`/specifications/${spec.id}`}
+                  className="font-mono text-blue-600 hover:underline"
+                >
+                  {spec.id}
+                </Link>
+                <StatusBadge status={spec.status} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500">No specifications</p>
+        )}
+      </div>
 
       {/* Description (Markdown) */}
       {description ? (

--- a/packages/web/src/components/specification/specification-detail.tsx
+++ b/packages/web/src/components/specification/specification-detail.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import type { Specification } from "@reqord/shared";
+import { StatusBadge } from "@/components/ui/badge";
+import { MarkdownRenderer } from "@/components/requirement/markdown-renderer";
+
+export function SpecificationDetail({
+  specification,
+  design,
+  requirementTitle,
+}: {
+  specification: Specification;
+  design: string | null;
+  requirementTitle: string | null;
+}) {
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <p className="text-sm text-gray-500">
+          <Link href="/specifications" className="hover:text-blue-600">
+            Specifications
+          </Link>
+          {" / "}
+          <span className="font-mono">{specification.id}</span>
+        </p>
+        <h1 className="mt-1 text-2xl font-bold font-mono">{specification.id}</h1>
+      </div>
+
+      {/* Badge */}
+      <div className="flex flex-wrap gap-2">
+        <StatusBadge status={specification.status} />
+      </div>
+
+      {/* Meta */}
+      <div className="grid grid-cols-2 gap-4 rounded-lg border border-gray-200 bg-white p-4 text-sm sm:grid-cols-4">
+        <div>
+          <p className="text-gray-500">Requirement</p>
+          <Link
+            href={`/requirements/${specification.requirementId}`}
+            className="font-mono text-blue-600 hover:underline"
+          >
+            {specification.requirementId}
+          </Link>
+          {requirementTitle && (
+            <p className="mt-0.5 text-xs text-gray-500 truncate">{requirementTitle}</p>
+          )}
+        </div>
+        <div>
+          <p className="text-gray-500">Version</p>
+          <p className="font-medium">{specification.version}</p>
+        </div>
+        <div>
+          <p className="text-gray-500">Created</p>
+          <p className="font-medium">
+            {new Date(specification.createdAt).toLocaleDateString("ja-JP")}
+          </p>
+        </div>
+        <div>
+          <p className="text-gray-500">Updated</p>
+          <p className="font-medium">
+            {new Date(specification.updatedAt).toLocaleDateString("ja-JP")}
+          </p>
+        </div>
+      </div>
+
+      {/* Supplementary Files */}
+      {specification.files.supplementary.length > 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <h2 className="mb-2 text-sm font-semibold text-gray-700">Supplementary Files</h2>
+          <ul className="list-inside list-disc space-y-1 text-sm">
+            {specification.files.supplementary.map((file) => (
+              <li key={file} className="font-mono text-gray-600">{file}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* Design (Markdown) */}
+      {design ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <h2 className="mb-2 text-sm font-semibold text-gray-700">Design</h2>
+          <MarkdownRenderer content={design} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/components/specification/specification-table.tsx
+++ b/packages/web/src/components/specification/specification-table.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { Specification, Status } from "@reqord/shared";
+import { StatusBadge } from "@/components/ui/badge";
+
+type SortKey = "id" | "requirementId" | "status" | "version" | "updatedAt";
+type SortDir = "asc" | "desc";
+
+const STATUS_OPTIONS: { value: Status | "all"; label: string }[] = [
+  { value: "all", label: "All Status" },
+  { value: "draft", label: "Draft" },
+  { value: "pending_approval", label: "Pending" },
+  { value: "approved", label: "Approved" },
+  { value: "deprecated", label: "Deprecated" },
+];
+
+export function SpecificationTable({
+  specifications,
+  requirementTitleMap,
+}: {
+  specifications: Specification[];
+  requirementTitleMap: Record<string, string>;
+}) {
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<Status | "all">("all");
+  const [sortKey, setSortKey] = useState<SortKey>("id");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const filtered = useMemo(() => {
+    let result = specifications;
+
+    if (statusFilter !== "all") {
+      result = result.filter((s) => s.status === statusFilter);
+    }
+
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      result = result.filter(
+        (s) =>
+          s.id.toLowerCase().includes(q) ||
+          s.requirementId.toLowerCase().includes(q) ||
+          (requirementTitleMap[s.requirementId] ?? "").toLowerCase().includes(q),
+      );
+    }
+
+    result = [...result].sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "id":
+          cmp = a.id.localeCompare(b.id);
+          break;
+        case "requirementId":
+          cmp = a.requirementId.localeCompare(b.requirementId);
+          break;
+        case "status":
+          cmp = a.status.localeCompare(b.status);
+          break;
+        case "version":
+          cmp = a.version.localeCompare(b.version);
+          break;
+        case "updatedAt":
+          cmp = a.updatedAt.localeCompare(b.updatedAt);
+          break;
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+
+    return result;
+  }, [specifications, requirementTitleMap, search, statusFilter, sortKey, sortDir]);
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  }
+
+  function renderSortHeader(column: SortKey, label: string) {
+    const arrow = sortKey === column ? (sortDir === "asc" ? " ↑" : " ↓") : "";
+    return (
+      <th
+        key={column}
+        className="cursor-pointer px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 hover:text-gray-900"
+        onClick={() => handleSort(column)}
+      >
+        {label}{arrow}
+      </th>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          type="text"
+          placeholder="Search by ID or requirement..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as Status | "all")}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
+        >
+          {STATUS_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <span className="text-sm text-gray-500">
+          {filtered.length} / {specifications.length} items
+        </span>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white shadow-sm">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {renderSortHeader("id", "ID")}
+              {renderSortHeader("requirementId", "Requirement")}
+              {renderSortHeader("status", "Status")}
+              {renderSortHeader("version", "Version")}
+              {renderSortHeader("updatedAt", "Updated")}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">
+                  No specifications found.
+                </td>
+              </tr>
+            ) : (
+              filtered.map((spec) => (
+                <tr key={spec.id} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-4 py-3 text-sm font-mono">
+                    <Link
+                      href={`/specifications/${spec.id}`}
+                      className="text-blue-600 hover:text-blue-800 hover:underline"
+                    >
+                      {spec.id}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <Link
+                      href={`/requirements/${spec.requirementId}`}
+                      className="text-blue-600 hover:text-blue-800 hover:underline"
+                    >
+                      <span className="font-mono">{spec.requirementId}</span>
+                      {requirementTitleMap[spec.requirementId] && (
+                        <span className="ml-2 text-gray-600">
+                          {requirementTitleMap[spec.requirementId]}
+                        </span>
+                      )}
+                    </Link>
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3">
+                    <StatusBadge status={spec.status} />
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                    {spec.version}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                    {new Date(spec.updatedAt).toLocaleDateString("ja-JP")}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/nav.tsx
+++ b/packages/web/src/components/ui/nav.tsx
@@ -17,6 +17,12 @@ export function Nav() {
                 Requirements
               </Link>
               <Link
+                href="/specifications"
+                className="text-sm font-medium text-gray-600 hover:text-gray-900"
+              >
+                Specifications
+              </Link>
+              <Link
                 href="/graph"
                 className="text-sm font-medium text-gray-600 hover:text-gray-900"
               >

--- a/packages/web/src/lib/get-repository.ts
+++ b/packages/web/src/lib/get-repository.ts
@@ -1,7 +1,10 @@
 import type { RequirementRepository } from "./repository";
 import { LocalRequirementRepository } from "./local-repository";
+import type { SpecificationRepository } from "./specification-repository";
+import { LocalSpecificationRepository } from "./local-specification-repository";
 
 let instance: RequirementRepository | null = null;
+let specInstance: SpecificationRepository | null = null;
 
 export function getRepository(): RequirementRepository {
   if (instance) {
@@ -19,4 +22,22 @@ export function getRepository(): RequirementRepository {
   }
 
   return instance;
+}
+
+export function getSpecificationRepository(): SpecificationRepository {
+  if (specInstance) {
+    return specInstance;
+  }
+
+  const dataSource = process.env.REQORD_DATA_SOURCE ?? "local";
+
+  switch (dataSource) {
+    case "local":
+      specInstance = new LocalSpecificationRepository();
+      break;
+    default:
+      throw new Error(`Unknown REQORD_DATA_SOURCE: ${dataSource}`);
+  }
+
+  return specInstance;
 }

--- a/packages/web/src/lib/local-specification-repository.ts
+++ b/packages/web/src/lib/local-specification-repository.ts
@@ -1,0 +1,61 @@
+import { SpecificationSchema, type Specification } from "@reqord/shared";
+import type { SpecificationRepository } from "./specification-repository";
+import * as fs from "./file-system";
+import { getSpecificationsDir } from "./reqord-root";
+
+export class LocalSpecificationRepository implements SpecificationRepository {
+  async findAll(): Promise<Specification[]> {
+    const specDir = getSpecificationsDir();
+    const files = await fs.readdirFiles(specDir, (name) =>
+      /^spec-\d{6}\.json$/.test(name),
+    );
+
+    const specifications: Specification[] = [];
+    for (const file of files.sort()) {
+      try {
+        const raw = await fs.readJSON<unknown>(fs.joinPath(specDir, file));
+        const result = SpecificationSchema.safeParse(raw);
+        if (result.success) {
+          specifications.push(result.data);
+        }
+      } catch {
+        // Skip files with invalid JSON
+      }
+    }
+    return specifications;
+  }
+
+  async findById(id: string): Promise<Specification | null> {
+    const specDir = getSpecificationsDir();
+    const jsonPath = fs.joinPath(specDir, `${id}.json`);
+
+    if (!(await fs.exists(jsonPath))) {
+      return null;
+    }
+
+    const raw = await fs.readJSON<unknown>(jsonPath);
+    const result = SpecificationSchema.safeParse(raw);
+    if (!result.success) {
+      throw new Error(`Invalid specification ${id}: ${result.error.message}`);
+    }
+    return result.data;
+  }
+
+  async loadDesign(id: string): Promise<string | null> {
+    const specDir = getSpecificationsDir();
+    const designPath = fs.joinPath(specDir, id, "design.md");
+
+    if (!(await fs.exists(designPath))) {
+      return null;
+    }
+
+    return fs.readText(designPath);
+  }
+
+  async findByRequirementId(
+    requirementId: string,
+  ): Promise<Specification[]> {
+    const all = await this.findAll();
+    return all.filter((spec) => spec.requirementId === requirementId);
+  }
+}

--- a/packages/web/src/lib/reqord-root.ts
+++ b/packages/web/src/lib/reqord-root.ts
@@ -1,4 +1,4 @@
-import { REQORD_DIR } from "@reqord/shared";
+import { REQORD_DIR, SPECIFICATIONS_DIR } from "@reqord/shared";
 import * as fs from "./file-system";
 
 let cachedRoot: string | null = null;
@@ -22,4 +22,8 @@ export function getReqordRoot(): string {
 
 export function getRequirementsDir(): string {
   return fs.joinPath(getReqordRoot(), REQORD_DIR, "requirements");
+}
+
+export function getSpecificationsDir(): string {
+  return fs.joinPath(getReqordRoot(), REQORD_DIR, SPECIFICATIONS_DIR);
 }

--- a/packages/web/src/lib/specification-data.ts
+++ b/packages/web/src/lib/specification-data.ts
@@ -1,0 +1,28 @@
+import type { Specification } from "@reqord/shared";
+import { getSpecificationRepository } from "./get-repository";
+
+export async function getAllSpecifications(): Promise<Specification[]> {
+  const repo = getSpecificationRepository();
+  return repo.findAll();
+}
+
+export async function getSpecificationById(
+  id: string,
+): Promise<Specification | null> {
+  const repo = getSpecificationRepository();
+  return repo.findById(id);
+}
+
+export async function getSpecificationDesign(
+  id: string,
+): Promise<string | null> {
+  const repo = getSpecificationRepository();
+  return repo.loadDesign(id);
+}
+
+export async function getSpecificationsByRequirementId(
+  requirementId: string,
+): Promise<Specification[]> {
+  const repo = getSpecificationRepository();
+  return repo.findByRequirementId(requirementId);
+}

--- a/packages/web/src/lib/specification-repository.ts
+++ b/packages/web/src/lib/specification-repository.ts
@@ -1,0 +1,8 @@
+import type { Specification } from "@reqord/shared";
+
+export interface SpecificationRepository {
+  findAll(): Promise<Specification[]>;
+  findById(id: string): Promise<Specification | null>;
+  loadDesign(id: string): Promise<string | null>;
+  findByRequirementId(requirementId: string): Promise<Specification[]>;
+}


### PR DESCRIPTION
## Summary

req-000013 (Specification CRUD) の Web UI 実装。一覧・詳細表示 + Requirement との相互リンク + グラフへの Specification 情報表示を実装。

## Changes

### Data Layer
- `SpecificationRepository` interface + `LocalSpecificationRepository` 実装
- `specification-data.ts`: クエリ関数 (`getAllSpecifications`, `getSpecificationById`, etc.)
- `reqord-root.ts`: `getSpecificationsDir()` 追加
- `get-repository.ts`: `getSpecificationRepository()` シングルトン追加

### Tests
- `local-specification-repository.test.ts`: 11 tests
  - `findAll()`: 複数ファイル読み取り、不正JSONスキップ
  - `findById()`: 存在する/しないID
  - `loadDesign()`: design.md読み取り
  - `findByRequirementId()`: フィルタ動作

### Pages & Components
- `/specifications`: 一覧ページ（テーブル + フィルタ + ソート）
- `/specifications/[id]`: 詳細ページ（メタ情報 + design.mdレンダリング）
- `SpecificationTable`: クライアントコンポーネント（Status フィルタ、テキスト検索、ソート）
- `SpecificationDetail`: Requirement リンク、StatusBadge、Markdown レンダリング

### Navigation & Cross-links
- `nav.tsx`: Specifications リンク追加
- `requirement-detail.tsx`: Specifications セクション追加（リンク + StatusBadge）
- `/requirements/[id]`: 紐づく Specification データ取得

### Graph Enhancement
- `graph/page.tsx`: Specification 件数データ取得
- `dependency-graph.tsx`: `specCountMap` props 追加
- `requirement-node.tsx`: Spec count バッジ表示（📄 N specs）

## Test Results

```
✓ 67 tests passed (11 new specification repository tests)
✓ pnpm build succeeds
✓ 0 lint errors
```

## Verification

- [x] `/specifications` で26件の仕様一覧が表示される
- [x] `/specifications/spec-000001` で詳細 + design.md が表示される
- [x] ナビに Specifications リンクがある
- [x] Requirement 詳細から紐づく Specification にリンクできる
- [x] グラフノードに spec count バッジが表示される
- [x] テストが通る
- [x] `pnpm build` が成功する

## Related

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)