### PR TITLE
fix: align VersionHistoryEntrySchema with actual data format

### DIFF
--- a/packages/shared/src/schemas/common.ts
+++ b/packages/shared/src/schemas/common.ts
@@ -20,9 +20,8 @@ export type FormatType = z.infer<typeof FormatTypeSchema>;
 
 export const VersionHistoryEntrySchema = z.object({
   version: z.string(),
-  status: StatusSchema,
-  gitCommit: z.string(),
-  approvedAt: z.string(),
-  approvedBy: z.array(z.string()),
+  changedAt: z.string(),
+  changeType: z.string(),
+  summary: z.string(),
 });
 export type VersionHistoryEntry = z.infer<typeof VersionHistoryEntrySchema>;


### PR DESCRIPTION
## Summary

- Fixed `VersionHistoryEntrySchema` to match the actual data format used in requirements
- This resolves the issue where 11 out of 23 requirements were silently excluded from the dependency graph due to schema validation failures

## Problem

The `VersionHistoryEntrySchema` was defined with fields that don't exist in the actual requirement JSON data:

```typescript
// Old (incorrect) schema
{
  version: string,
  status: StatusSchema,      // ❌ doesn't exist
  gitCommit: string,         // ❌ doesn't exist
  approvedAt: string,        // ❌ doesn't exist
  approvedBy: string[],      // ❌ doesn't exist
}
```

Actual data format in requirements:

```json
{
  "version": "1.0.0",
  "changedAt": "2026-02-07T10:00:00Z",
  "changeType": "created",
  "summary": "初版作成"
}
```

This mismatch caused `RequirementSchema.safeParse()` to fail for 11 requirements, which were then silently skipped in `LocalRequirementRepository.findAll()`.

## Solution

Updated schema to match actual data format:

```typescript
// New (correct) schema
{
  version: string,
  changedAt: string,    // ✅ timestamp
  changeType: string,   // ✅ created/modified
  summary: string,      // ✅ change description
}
```

## Impact

**Before:**
- Only 12/23 requirements displayed in dependency graph
- Missing requirements: req-000002, 003, 004, 006, 008, 013, 016, 017, 019, 020, 021

**After:**
- All 23/23 requirements now display correctly
- All tests pass (163 tests, 14 test files)
- Build successful for all packages

## Test Results

```
✓ All 23 requirement files pass schema validation
✓ 163 tests passed (14 test files)
✓ Build successful: @reqord/shared, @reqord/cli, @reqord/web
```

## Files Changed

- `packages/shared/src/schemas/common.ts` - Updated `VersionHistoryEntrySchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)