### PR TITLE
fix: add implemented status color to graph node

### DIFF
--- a/packages/web/src/components/graph/requirement-node.tsx
+++ b/packages/web/src/components/graph/requirement-node.tsx
@@ -8,6 +8,7 @@ const STATUS_COLORS: Record<string, string> = {
   draft: "border-gray-300 bg-gray-50",
   pending_approval: "border-yellow-300 bg-yellow-50",
   approved: "border-green-300 bg-green-50",
+  implemented: "border-blue-300 bg-blue-50",
   deprecated: "border-red-300 bg-red-50",
 };
 


### PR DESCRIPTION
## Summary
- グラフノードの `STATUS_COLORS` に `implemented` ステータスの色定義（`border-blue-300 bg-blue-50`）を追加
- `badge.tsx` の青色系統と一致するカラースキームに統一

## Test plan
- [x] `implemented` ステータスの要件がグラフ上で青色ボーダー・背景で表示されることを確認
- [x] 他のステータス（draft, pending_approval, approved, deprecated）の表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)