### PR TITLE
docs: migrate spec-000016/024 to HTML comment tag format

### DIFF
--- a/.reqord/specifications/spec-000016/design.md
+++ b/.reqord/specifications/spec-000016/design.md
@@ -2,7 +2,7 @@
 
 ## 1. 設計概要
 
-SpecificationからGitHub Issueを自動生成する機能を提供する。Anthropic SDK（Claude API）を使用してSpecificationのdesign.mdを解析し、実装タスクに分解する。分解戦略（by-layer, by-feature, by-requirement, custom）を選択可能にし、並列グループ（P0/P1/P2）とクリティカルパスを自動計算する。GitHub Issue Templateの適用、ラベル自動付与、`--dry-run`によるプレビューをサポートする。本specでは分解とIssue作成（書き込み操作）を扱い、Issue同期・追跡（spec-000024）は対象外とする。
+SpecificationからGitHub Issueを自動生成する機能を提供する。Anthropic SDK（Claude API）を使用してSpecificationのdesign.mdを解析し、実装タスクに分解する。分解戦略（by-layer, by-feature, by-requirement, custom）を選択可能にし、並列グループ（P0/P1/P2）とクリティカルパスを自動計算する。GitHub Issue Templateの適用、HTMLコメントタグによるメタデータ埋め込み、`--dry-run`によるプレビューをサポートする。本specでは分解とIssue作成（書き込み操作）を扱い、Issue同期・追跡（spec-000024）は対象外とする。
 
 ## 2. アーキテクチャ
 
@@ -200,12 +200,26 @@ body:
       label: 優先度
 ```
 
-### 3.7 ラベル自動付与
+### 3.7 メタデータ付与
 
-各Issueに以下のラベルを自動付与:
+各Issueに以下のメタデータを付与する。
+
+#### 3.7.1 HTMLコメントタグ
+
+Issue本文にHTMLコメントタグを埋め込み、Specification IDを記録する:
+
+```html
+<!-- reqord:specification {"specificationId":"spec-NNNNNN"} -->
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|------|------|------|
+| `specificationId` | string | Yes | 対象Specification ID |
+
+#### 3.7.2 ラベル
+
+有限集合のラベルのみをGitHub UIフィルタ用に付与:
 - `reqord-generated`: reqordから生成されたIssue
-- `spec:<spec-id>`: 対象Specification（例: `spec:spec-000016`）
-- `req:<req-id>`: 関連Requirement（例: `req:req-000016`）
 - `P<n>`: 優先度（例: `P0`, `P1`, `P2`）
 
 ### 3.8 SpecificationSchema拡張
@@ -259,8 +273,9 @@ function calculateCriticalPath(tasks: DecomposedTask[]): string[] {
         → DecompositionResult返却
       → Issue Template読み込み
       → 各タスクに対して:
-        → ラベル生成: ["reqord-generated", "spec:spec-000016", "req:req-000016", "P0"]
         → Issue本文生成（テンプレート適用）
+        → HTMLコメントタグ埋め込み: <!-- reqord:specification {"specificationId":"spec-000016"} -->
+        → ラベル生成: ["reqord-generated", "P0"]
         → githubRepo.createIssue({ title, body, labels })
           → gh issue create --title "..." --body "..." --label "..."
       → Specification JSONにimplementationフィールド記録
@@ -299,7 +314,8 @@ function calculateCriticalPath(tasks: DecomposedTask[]): string[] {
   - 並列グループ計算: P0/P1/P2への正しい分類
   - クリティカルパス計算: 線形依存、分岐依存、独立タスク
 - **issue-service**:
-  - ラベル生成ロジック
+  - HTMLコメントタグ埋め込みロジック
+  - ラベル生成ロジック（`reqord-generated`, `P<n>`）
   - Issue本文テンプレート適用
   - dry-runモード: GitHub API呼び出しなし
   - maxIssues制限の動作

--- a/.reqord/specifications/spec-000024/design.md
+++ b/.reqord/specifications/spec-000024/design.md
@@ -2,7 +2,7 @@
 
 ## 1. 設計概要
 
-GitHub Issueの状態をローカルのSpecification JSONに同期し、実装進捗を追跡する機能を提供する。spec-000016で作成されたIssueの最新状態をGitHub APIから取得し、`implementation.issues[].state` および `implementation.progress` フィールドを更新する。`gh` CLIを通じたGitHub API呼び出しにより、追加の認証設定なしでIssue情報を取得する。メタデータの整合性検証（Issue存在確認、ラベル一致、循環依存チェック）も提供する。
+GitHub Issueの状態をローカルのSpecification JSONに同期し、実装進捗を追跡する機能を提供する。spec-000016で作成されたIssueの最新状態をGitHub APIから取得し、`implementation.issues[].state` および `implementation.progress` フィールドを更新する。`gh` CLIを通じたGitHub API呼び出しにより、追加の認証設定なしでIssue情報を取得する。メタデータの整合性検証（Issue存在確認、HTMLコメントタグ一致、循環依存チェック）も提供する。
 
 ## 2. アーキテクチャ
 
@@ -90,7 +90,7 @@ reqord issue validate --all
 |---------|------|--------|
 | Issue存在確認 | 記録されたIssue番号がGitHub上に存在するか | error |
 | ラベル一致 | `reqord-generated` ラベルが付与されているか | warning |
-| spec-idラベル | `spec:<spec-id>` ラベルが正しいか | warning |
+| specificationコメント一致 | Issue本文に `<!-- reqord:specification {"specificationId":"<spec-id>"} -->` が存在するか | warning |
 | 循環依存 | Issue間の依存関係に循環がないか | error |
 | 重複Issue | 同一タスクに対する重複Issueがないか | warning |
 | Issueオープン状態 | 全Issueクローズ済みならprogress=100%か | info |
@@ -181,6 +181,7 @@ async function syncSpecification(cwd: string, specId: string): Promise<SyncResul
 export interface GitHubIssue {
   number: number;
   title: string;
+  body: string;
   state: "open" | "closed";
   labels: string[];
   assignees: string[];
@@ -210,13 +211,13 @@ import { execFile } from "node:child_process";
 async function getIssue(cwd: string, issueNumber: number): Promise<GitHubIssue> {
   const result = await execGh(cwd, [
     "issue", "view", String(issueNumber),
-    "--json", "number,title,state,labels,assignees,createdAt,updatedAt,closedAt",
+    "--json", "number,title,body,state,labels,assignees,createdAt,updatedAt,closedAt",
   ]);
   return parseGitHubIssue(JSON.parse(result));
 }
 
 async function listIssues(cwd: string, options: ListOptions): Promise<GitHubIssue[]> {
-  const args = ["issue", "list", "--json", "number,title,state,labels,assignees,createdAt,updatedAt,closedAt"];
+  const args = ["issue", "list", "--json", "number,title,body,state,labels,assignees,createdAt,updatedAt,closedAt"];
   if (options.labels?.length) {
     args.push("--label", options.labels.join(","));
   }
@@ -335,7 +336,8 @@ function mapGitHubState(ghState: "open" | "closed"): "open" | "in_progress" | "c
       → specRepo.findById(cwd, "spec-000016") → Specification取得
       → 各Issueについて:
         → githubRepo.getIssue(cwd, issue.number) → Issue存在確認
-        → ラベル確認: "reqord-generated", "spec:spec-000016" が存在するか
+        → ラベル確認: "reqord-generated" が存在するか
+        → HTMLコメントタグ確認: <!-- reqord:specification {"specificationId":"spec-000016"} --> がbodyに存在するか
       → 循環依存チェック:
         → Issue間のblockedBy関係をグラフとして構築
         → トポロジカルソートで循環検出
@@ -345,7 +347,7 @@ function mapGitHubState(ghState: "open" | "closed"): "open" | "in_progress" | "c
   → 検証結果表示:
     ✓ Issue #42 exists
     ✓ Issue #43 exists
-    ⚠ Issue #43 missing label "spec:spec-000016"
+    ⚠ Issue #43 missing specification comment tag
     ✓ No circular dependencies
 ```
 
@@ -362,7 +364,8 @@ function mapGitHubState(ghState: "open" | "closed"): "open" | "in_progress" | "c
 - **issueSyncService.validateSpecification**:
   - 全チェック正常: ValidationResult.errors = []
   - Issue不存在: error severity
-  - ラベル不一致: warning severity
+  - ラベル不一致（reqord-generated欠落）: warning severity
+  - HTMLコメントタグ不一致（specificationコメント欠落）: warning severity
   - 循環依存検出: error severity
 - **calculateProgress**:
   - 0件: percentage = 0

--- a/docs/main.md
+++ b/docs/main.md
@@ -798,15 +798,7 @@ body:
       value: |
         ---
         ### 🔗 Reqord Metadata
-        <!-- reqord:metadata
-        {
-          "specificationId": "spec-001",
-          "requirementIds": ["req-001"],
-          "parallelGroup": 1,
-          "isCriticalPath": true,
-          "estimatedHours": 4
-        }
-        -->
+        <!-- reqord:specification {"specificationId":"spec-001"} -->
 ```
 
 ---


### PR DESCRIPTION
## Summary
- spec-000016 (Issue生成) と spec-000024 (Issue同期) の設計書を、ラベル方式 (`spec:<spec-id>` / `req:<req-id>`) から HTMLコメントタグ方式 (`<!-- reqord:specification {"specificationId":"..."} -->`) に移行
- `docs/main.md` の `reqord:metadata` 統合フォーマットを `reqord:specification` に変更
- feedbackで実証済みのHTMLコメントタグ方式との命名一貫性 (`reqord:<namespace>`) を確保

## Changes
### spec-000016/design.md
- Section 1: 概要の「ラベル自動付与」→「HTMLコメントタグによるメタデータ埋め込み」
- Section 3.7: 「ラベル自動付与」→「メタデータ付与」(3.7.1 HTMLコメントタグ / 3.7.2 ラベル)
- Section 4: データフロー内のラベル生成をHTMLコメント埋め込みに変更
- Section 5: テスト方針にHTMLコメントタグテスト追加

### spec-000024/design.md
- Section 1: 「ラベル一致」→「HTMLコメントタグ一致」
- Section 3.2: validate検証項目の `spec-idラベル` → `specificationコメント一致`
- Section 3.4: `GitHubIssue` interfaceに `body` フィールド追加
- Section 4: 検証フローのラベル確認 → HTMLコメントタグ確認
- Section 5: テスト方針にHTMLコメントタグ不一致テスト追加

### docs/main.md
- `<!-- reqord:metadata {...} -->` → `<!-- reqord:specification {"specificationId":"spec-001"} -->`

## Test plan
- [x] `spec:<spec-id>` / `req:<req-id>` ラベル参照が設計書から除去されていること
- [x] `<!-- reqord:specification {...} -->` フォーマットが統一されていること
- [x] `reqord-generated` / `P<n>` ラベルは維持されていること
- [x] feedbackの `reqord:feedback` との命名一貫性が保たれていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)