### PR TITLE
feat: add currentApproval field to SpecificationSchema (#82)

### DIFF
--- a/packages/shared/src/schemas/specification.test.ts
+++ b/packages/shared/src/schemas/specification.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import { SpecificationSchema } from "./specification.js";
+
+describe("SpecificationSchema", () => {
+  const baseSpecification = {
+    id: "spec-000001",
+    requirementId: "req-000001",
+    version: "1.0.0",
+    status: "draft" as const,
+    createdAt: "2026-02-09T12:00:00Z",
+    updatedAt: "2026-02-09T12:00:00Z",
+    versionHistory: [],
+    files: {
+      design: "specifications/spec-000001/design.md",
+      supplementary: [],
+    },
+    flags: [],
+  };
+
+  describe("currentApproval", () => {
+    it("currentApprovalを持つ有効なSpecificationを受け入れる", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          version: "1.0.0",
+          phase: "specification" as const,
+          prNumber: 123,
+          prUrl: "https://github.com/owner/repo/pull/123",
+          approvedBy: ["user1", "user2"],
+          approvedAt: "2026-02-09T12:00:00Z",
+        },
+      };
+
+      const result = SpecificationSchema.parse(specification);
+      expect(result.currentApproval).toEqual({
+        version: "1.0.0",
+        phase: "specification",
+        prNumber: 123,
+        prUrl: "https://github.com/owner/repo/pull/123",
+        approvedBy: ["user1", "user2"],
+        approvedAt: "2026-02-09T12:00:00Z",
+      });
+    });
+
+    it("currentApprovalなしの既存フォーマットを受け入れる（後方互換性）", () => {
+      const result = SpecificationSchema.parse(baseSpecification);
+      expect(result.currentApproval).toBeUndefined();
+    });
+
+    it("approvedAtが省略されたcurrentApprovalを受け入れる", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          version: "1.0.0",
+          phase: "specification" as const,
+          prNumber: 456,
+          prUrl: "https://github.com/owner/repo/pull/456",
+          approvedBy: ["user1"],
+        },
+      };
+
+      const result = SpecificationSchema.parse(specification);
+      expect(result.currentApproval?.approvedAt).toBeUndefined();
+    });
+
+    it("phaseが'requirement'を受け入れる", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          version: "1.0.0",
+          phase: "requirement" as const,
+          prNumber: 123,
+          prUrl: "https://github.com/owner/repo/pull/123",
+          approvedBy: ["user1"],
+        },
+      };
+
+      const result = SpecificationSchema.parse(specification);
+      expect(result.currentApproval?.phase).toBe("requirement");
+    });
+
+    it("phaseが'specification'を受け入れる", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          version: "1.0.0",
+          phase: "specification" as const,
+          prNumber: 123,
+          prUrl: "https://github.com/owner/repo/pull/123",
+          approvedBy: ["user1"],
+        },
+      };
+
+      const result = SpecificationSchema.parse(specification);
+      expect(result.currentApproval?.phase).toBe("specification");
+    });
+
+    it("無効なphaseを拒否する", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          version: "1.0.0",
+          phase: "invalid",
+          prNumber: 123,
+          prUrl: "https://github.com/owner/repo/pull/123",
+          approvedBy: ["user1"],
+        },
+      };
+
+      expect(() => SpecificationSchema.parse(specification)).toThrow();
+    });
+
+    it("versionが欠けている場合は拒否する", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          phase: "specification",
+          prNumber: 123,
+          prUrl: "https://github.com/owner/repo/pull/123",
+          approvedBy: ["user1"],
+        },
+      };
+
+      expect(() => SpecificationSchema.parse(specification)).toThrow();
+    });
+
+    it("prNumberが欠けている場合は拒否する", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          version: "1.0.0",
+          phase: "specification",
+          prUrl: "https://github.com/owner/repo/pull/123",
+          approvedBy: ["user1"],
+        },
+      };
+
+      expect(() => SpecificationSchema.parse(specification)).toThrow();
+    });
+
+    it("prNumberが数値以外の場合は拒否する", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          version: "1.0.0",
+          phase: "specification",
+          prNumber: "123",
+          prUrl: "https://github.com/owner/repo/pull/123",
+          approvedBy: ["user1"],
+        },
+      };
+
+      expect(() => SpecificationSchema.parse(specification)).toThrow();
+    });
+
+    it("approvedByが配列でない場合は拒否する", () => {
+      const specification = {
+        ...baseSpecification,
+        currentApproval: {
+          version: "1.0.0",
+          phase: "specification",
+          prNumber: 123,
+          prUrl: "https://github.com/owner/repo/pull/123",
+          approvedBy: "user1",
+        },
+      };
+
+      expect(() => SpecificationSchema.parse(specification)).toThrow();
+    });
+  });
+});

--- a/packages/shared/src/schemas/specification.ts
+++ b/packages/shared/src/schemas/specification.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { StatusSchema, VersionHistoryEntrySchema } from "./common.js";
-import { FeedbackFlagSchema } from "./requirement.js";
+import { FeedbackFlagSchema, CurrentApprovalSchema } from "./requirement.js";
 
 export const SpecificationSchema = z.object({
   id: z.string().regex(/^spec-\d{6}$/),
@@ -15,6 +15,7 @@ export const SpecificationSchema = z.object({
     supplementary: z.array(z.string()).default([]),
   }),
   flags: z.array(FeedbackFlagSchema).default([]),
+  currentApproval: CurrentApprovalSchema.optional(),
 });
 
 export type Specification = z.infer<typeof SpecificationSchema>;


### PR DESCRIPTION
## Summary
- SpecificationSchemaに`currentApproval`フィールドを追加（RequirementSchemaと同一パターン）
- フィールドはoptionalで既存データとの後方互換性を維持
- Zodスキーマのユニットテスト10件を追加

## Test plan
- [x] currentApproval付きの有効なSpecificationを受け入れる
- [x] currentApprovalなしの既存フォーマットを受け入れる（後方互換性）
- [x] 各フィールドのバリデーション（phase, version, prNumber, approvedBy）
- [x] 全303テスト通過

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)