### PR TITLE
feat: implement specification approval prerequisites check (#83)

### DIFF
--- a/packages/cli/src/services/specification-service.test.ts
+++ b/packages/cli/src/services/specification-service.test.ts
@@ -34,6 +34,7 @@ import {
   listSpecifications,
   showSpecification,
   updateSpecDesign,
+  checkSpecApprovalPrerequisites,
 } from "./specification-service.js";
 
 const mockSpecRepo = vi.mocked(specRepo);
@@ -252,6 +253,87 @@ describe("updateSpecDesign", () => {
 
     await expect(
       updateSpecDesign("/cwd", "spec-999999"),
+    ).rejects.toThrow("Specification spec-999999 not found.");
+  });
+});
+
+// --- Cycle 5: checkSpecApprovalPrerequisites ---
+
+describe("checkSpecApprovalPrerequisites", () => {
+  it("Specificationがdraftで関連Requirementがapprovedで設計済みの場合は成功", async () => {
+    mockSpecRepo.findById.mockResolvedValue(makeSpecification({ status: "draft" }));
+    mockReqRepo.findById.mockResolvedValue(makeRequirement({ status: "approved" }));
+    mockSpecRepo.loadFile.mockResolvedValue("# 実際の設計内容\n\n設計の詳細...");
+
+    const result = await checkSpecApprovalPrerequisites("/cwd", "spec-000001");
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("Specificationがdraft以外の場合はエラー", async () => {
+    mockSpecRepo.findById.mockResolvedValue(makeSpecification({ status: "approved" }));
+    mockReqRepo.findById.mockResolvedValue(makeRequirement({ status: "approved" }));
+    mockSpecRepo.loadFile.mockResolvedValue("# 設計内容");
+
+    const result = await checkSpecApprovalPrerequisites("/cwd", "spec-000001");
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContainEqual(expect.stringContaining("draft ではありません"));
+  });
+
+  it("関連Requirementがapprovedの場合は成功", async () => {
+    // same as first test but explicit about requirement being approved
+    mockSpecRepo.findById.mockResolvedValue(makeSpecification({ status: "draft" }));
+    mockReqRepo.findById.mockResolvedValue(makeRequirement({ status: "approved" }));
+    mockSpecRepo.loadFile.mockResolvedValue("# 設計内容");
+
+    const result = await checkSpecApprovalPrerequisites("/cwd", "spec-000001");
+    expect(result.ok).toBe(true);
+  });
+
+  it("関連Requirementがpending_approvalの場合は成功", async () => {
+    mockSpecRepo.findById.mockResolvedValue(makeSpecification({ status: "draft" }));
+    mockReqRepo.findById.mockResolvedValue(makeRequirement({ status: "pending_approval" }));
+    mockSpecRepo.loadFile.mockResolvedValue("# 設計内容");
+
+    const result = await checkSpecApprovalPrerequisites("/cwd", "spec-000001");
+    expect(result.ok).toBe(true);
+  });
+
+  it("関連Requirementがdraftの場合はエラー", async () => {
+    mockSpecRepo.findById.mockResolvedValue(makeSpecification({ status: "draft" }));
+    mockReqRepo.findById.mockResolvedValue(makeRequirement({ status: "draft" }));
+    mockSpecRepo.loadFile.mockResolvedValue("# 設計内容");
+
+    const result = await checkSpecApprovalPrerequisites("/cwd", "spec-000001");
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContainEqual(expect.stringContaining("未承認"));
+  });
+
+  it("design.mdがテンプレートのままの場合はエラー", async () => {
+    mockSpecRepo.findById.mockResolvedValue(makeSpecification({ status: "draft" }));
+    mockReqRepo.findById.mockResolvedValue(makeRequirement({ status: "approved" }));
+    mockSpecRepo.loadFile.mockResolvedValue("# {{id}} - Design\n\n## 対象要件: {{requirementId}}\n\n## 設計概要\n\n{{設計の目的とスコープを記述}}");
+
+    const result = await checkSpecApprovalPrerequisites("/cwd", "spec-000001");
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContainEqual(expect.stringContaining("テンプレートのまま"));
+  });
+
+  it("design.mdがnullの場合はエラー", async () => {
+    mockSpecRepo.findById.mockResolvedValue(makeSpecification({ status: "draft" }));
+    mockReqRepo.findById.mockResolvedValue(makeRequirement({ status: "approved" }));
+    mockSpecRepo.loadFile.mockResolvedValue(null);
+
+    const result = await checkSpecApprovalPrerequisites("/cwd", "spec-000001");
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContainEqual(expect.stringContaining("テンプレートのまま"));
+  });
+
+  it("Specificationが存在しない場合はエラーをthrow", async () => {
+    mockSpecRepo.findById.mockResolvedValue(null);
+
+    await expect(
+      checkSpecApprovalPrerequisites("/cwd", "spec-999999")
     ).rejects.toThrow("Specification spec-999999 not found.");
   });
 });

--- a/packages/cli/src/services/specification-service.ts
+++ b/packages/cli/src/services/specification-service.ts
@@ -144,3 +144,43 @@ export async function updateSpecDesign(
 
   return { filePath, updated: true };
 }
+
+// --- Approval Prerequisites ---
+
+export interface PrerequisiteResult {
+  ok: boolean;
+  errors: string[];
+}
+
+export async function checkSpecApprovalPrerequisites(
+  cwd: string,
+  specId: string,
+): Promise<PrerequisiteResult> {
+  const spec = await specRepo.findById(cwd, specId);
+  if (!spec) {
+    throw new Error(`Specification ${specId} not found.`);
+  }
+
+  const errors: string[] = [];
+
+  // 1. Status check
+  if (spec.status !== "draft") {
+    errors.push(`Specificationのステータスが draft ではありません（現在: ${spec.status}）`);
+  }
+
+  // 2. Related requirement status check
+  const req = await reqRepo.findById(cwd, spec.requirementId);
+  if (!req) {
+    errors.push(`関連要件 ${spec.requirementId} が見つかりません`);
+  } else if (req.status !== "approved" && req.status !== "pending_approval") {
+    errors.push(`関連要件 ${spec.requirementId} が未承認です（現在: ${req.status}）`);
+  }
+
+  // 3. design.md content check
+  const design = await specRepo.loadFile(cwd, specId, "design.md");
+  if (!design || design.includes("{{")) {
+    errors.push("design.mdがテンプレートのままです。設計内容を記述してください。");
+  }
+
+  return { ok: errors.length === 0, errors };
+}


### PR DESCRIPTION
## Summary
- `checkSpecApprovalPrerequisites`関数を`specification-service.ts`に追加
- 3つの前提条件（ステータス、Requirement承認状態、design.md内容）を検証
- ユニットテスト8件を追加

## Test plan
- [x] Specificationがdraftで関連Requirementがapprovedで設計済みの場合は成功
- [x] Specificationがdraft以外の場合はエラー
- [x] 関連Requirementがpending_approvalの場合は成功
- [x] 関連Requirementがdraftの場合はエラー
- [x] design.mdがテンプレートのままの場合はエラー
- [x] design.mdがnullの場合はエラー
- [x] 全301テスト通過

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)