### PR TITLE
feat: implement PR body template and designSummary extraction (#84)

### DIFF
--- a/packages/cli/src/services/spec-approval-helpers.test.ts
+++ b/packages/cli/src/services/spec-approval-helpers.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { extractDesignSummary, buildSpecApprovalPrBody } from "./spec-approval-helpers.js";
+
+describe("extractDesignSummary", () => {
+  it("'## 1. 設計概要' セクションの内容を抽出する", () => {
+    const designContent = `# spec-000015 - Design
+
+## 1. 設計概要
+
+Specificationの承認プロセスをGitHub PRベースで管理する。
+
+## 2. アーキテクチャ
+
+詳細な設計...`;
+
+    const result = extractDesignSummary(designContent);
+    expect(result).toBe("Specificationの承認プロセスをGitHub PRベースで管理する。");
+  });
+
+  it("'## 設計概要' セクションからも抽出できる", () => {
+    const designContent = `# Design
+
+## 設計概要
+
+シンプルな設計内容。
+
+## インターフェース設計
+
+入力定義...`;
+
+    const result = extractDesignSummary(designContent);
+    expect(result).toBe("シンプルな設計内容。");
+  });
+
+  it("設計概要セクションがない場合はデフォルトメッセージを返す", () => {
+    const designContent = `# Design
+
+## アーキテクチャ
+
+内容...`;
+
+    const result = extractDesignSummary(designContent);
+    expect(result).toBe("(設計概要なし)");
+  });
+
+  it("設計概要が複数行の場合はすべて含む", () => {
+    const designContent = `# Design
+
+## 1. 設計概要
+
+1行目の説明。
+2行目の詳細。
+3行目の補足。
+
+## 2. 次のセクション`;
+
+    const result = extractDesignSummary(designContent);
+    expect(result).toBe("1行目の説明。\n2行目の詳細。\n3行目の補足。");
+  });
+
+  it("設計概要が最後のセクションの場合も正しく抽出する", () => {
+    const designContent = `# Design
+
+## 1. 設計概要
+
+最後のセクションの内容。`;
+
+    const result = extractDesignSummary(designContent);
+    expect(result).toBe("最後のセクションの内容。");
+  });
+
+  it("空文字列の場合はデフォルトメッセージを返す", () => {
+    expect(extractDesignSummary("")).toBe("(設計概要なし)");
+  });
+});
+
+describe("buildSpecApprovalPrBody", () => {
+  it("テンプレートに各フィールドが正しく埋め込まれる", () => {
+    const result = buildSpecApprovalPrBody({
+      specId: "spec-000015",
+      reqId: "req-000015",
+      reqTitle: "承認フロー実装",
+      version: "1.0.0",
+      designSummary: "設計の概要説明。",
+    });
+
+    expect(result).toContain("| Specification ID | spec-000015 |");
+    expect(result).toContain("| Requirement ID | req-000015 |");
+    expect(result).toContain("| 要件タイトル | 承認フロー実装 |");
+    expect(result).toContain("| バージョン | 1.0.0 |");
+    expect(result).toContain("### 設計概要\n設計の概要説明。");
+    expect(result).toContain("status: draft → pending_approval");
+    expect(result).toContain("`specifications/spec-000015/design.md`");
+  });
+
+  it("PR本文が仕様承認依頼ヘッダーで始まる", () => {
+    const result = buildSpecApprovalPrBody({
+      specId: "spec-000001",
+      reqId: "req-000001",
+      reqTitle: "テスト",
+      version: "1.0.0",
+      designSummary: "概要",
+    });
+
+    expect(result).toMatch(/^## 仕様承認依頼/);
+  });
+
+  it("マージ後の案内メッセージが含まれる", () => {
+    const result = buildSpecApprovalPrBody({
+      specId: "spec-000001",
+      reqId: "req-000001",
+      reqTitle: "テスト",
+      version: "1.0.0",
+      designSummary: "概要",
+    });
+
+    expect(result).toContain("このPRをマージすると、仕様のステータスが `approved` に更新されます。");
+  });
+});

--- a/packages/cli/src/services/spec-approval-helpers.ts
+++ b/packages/cli/src/services/spec-approval-helpers.ts
@@ -1,0 +1,53 @@
+export function extractDesignSummary(designContent: string): string {
+  if (!designContent) {
+    return "(設計概要なし)";
+  }
+
+  // Split content into sections by ## headings
+  const sections = designContent.split(/\n(?=##\s)/);
+
+  // Find the section that starts with "## 設計概要" or "## 1. 設計概要"
+  const summarySection = sections.find(section =>
+    /^##\s+(?:\d+\.\s+)?設計概要/.test(section)
+  );
+
+  if (!summarySection) {
+    return "(設計概要なし)";
+  }
+
+  // Extract content after the heading
+  const contentAfterHeading = summarySection.replace(/^##\s+(?:\d+\.\s+)?設計概要\s*\n+/, '');
+  const summary = contentAfterHeading.trim();
+
+  return summary || "(設計概要なし)";
+}
+
+export interface SpecApprovalPrBodyParams {
+  specId: string;
+  reqId: string;
+  reqTitle: string;
+  version: string;
+  designSummary: string;
+}
+
+export function buildSpecApprovalPrBody(params: SpecApprovalPrBodyParams): string {
+  return `## 仕様承認依頼
+
+| フィールド | 値 |
+|-----------|------|
+| Specification ID | ${params.specId} |
+| Requirement ID | ${params.reqId} |
+| 要件タイトル | ${params.reqTitle} |
+| バージョン | ${params.version} |
+
+### 設計概要
+${params.designSummary}
+
+### 変更内容
+status: draft → pending_approval
+
+### 設計ファイル
+- \`specifications/${params.specId}/design.md\`
+
+> このPRをマージすると、仕様のステータスが \`approved\` に更新されます。`;
+}


### PR DESCRIPTION
## Summary
- `extractDesignSummary`関数: design.mdから設計概要セクションを自動抽出
- `buildSpecApprovalPrBody`関数: Specification承認PR本文テンプレート生成
- ユニットテスト9件を追加

## Test plan
- [x] `## 1. 設計概要` / `## 設計概要` 両形式からの抽出
- [x] 複数行、最後のセクション、セクションなし等のエッジケース
- [x] PR本文テンプレートのフィールド埋め込み確認
- [x] 全302テスト通過

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)