### PR TITLE
fix(reqord): update remaining .json refs to .yaml

### DIFF
--- a/packages/cli/src/commands/context/init.ts
+++ b/packages/cli/src/commands/context/init.ts
@@ -26,10 +26,10 @@ export const contextInitCommand = new Command("init")
       console.log(`  Language: ${context.language}`);
       console.log("");
       console.log(chalk.gray("Generated files:"));
-      console.log(chalk.gray("  context/context.json"));
-      console.log(chalk.gray("  context/product.json"));
-      console.log(chalk.gray("  context/technical.json"));
-      console.log(chalk.gray("  context/structure.json"));
+      console.log(chalk.gray("  context/context.yaml"));
+      console.log(chalk.gray("  context/product.yaml"));
+      console.log(chalk.gray("  context/technical.yaml"));
+      console.log(chalk.gray("  context/structure.yaml"));
       console.log(chalk.gray("  context/domain/"));
       console.log("");
       console.log(

--- a/packages/cli/src/commands/context/update.ts
+++ b/packages/cli/src/commands/context/update.ts
@@ -12,9 +12,9 @@ export const contextUpdateCommand = new Command("update")
   .description("Update project context")
   .option("-n, --name <name>", "New project name")
   .option("-v, --version <version>", "New project version")
-  .option("--product <path>", "JSON file to patch product.json")
-  .option("--technical <path>", "JSON file to patch technical.json")
-  .option("--structure <path>", "JSON file to patch structure.json")
+  .option("--product <path>", "JSON file to patch product.yaml")
+  .option("--technical <path>", "JSON file to patch technical.yaml")
+  .option("--structure <path>", "JSON file to patch structure.yaml")
   .option("--json", "Output as JSON")
   .action(
     async (options: {
@@ -61,7 +61,7 @@ export const contextUpdateCommand = new Command("update")
         }
         if (result.updatedFiles.length > 0) {
           console.log(
-            `  files: ${result.updatedFiles.map((f) => `${f}.json`).join(", ")} updated`,
+            `  files: ${result.updatedFiles.map((f) => `${f}.yaml`).join(", ")} updated`,
           );
         }
       } catch (error) {

--- a/packages/cli/src/commands/feedback/close.ts
+++ b/packages/cli/src/commands/feedback/close.ts
@@ -5,7 +5,7 @@ import { handleError } from "../../utils/error-handler.js";
 import { parseIssueNumber } from "../../utils/display.js";
 
 export const feedbackCloseCommand = new Command("close")
-  .description("Close feedback (updates index.json and closes GitHub Issue)")
+  .description("Close feedback (updates index.yaml and closes GitHub Issue)")
   .argument("<issue-number>", "GitHub issue number")
   .action(async (issueNumberStr: string) => {
     try {

--- a/packages/cli/src/commands/feedback/list.ts
+++ b/packages/cli/src/commands/feedback/list.ts
@@ -7,7 +7,7 @@ import { handleError } from "../../utils/error-handler.js";
 import { FEEDBACK_STATUS_COLORS, identityColor } from "../../utils/display.js";
 
 export const feedbackListCommand = new Command("list")
-  .description("List feedback issues from index.json")
+  .description("List feedback issues from index.yaml")
   .option("--state <state>", "Filter by state (open|closed|all)", "all")
   .option("--type <type>", "Filter by type")
   .option("--json", "Output as JSON")

--- a/packages/cli/src/commands/feedback/show.ts
+++ b/packages/cli/src/commands/feedback/show.ts
@@ -5,7 +5,7 @@ import { handleError } from "../../utils/error-handler.js";
 import { parseIssueNumber } from "../../utils/display.js";
 
 export const feedbackShowCommand = new Command("show")
-  .description("Show feedback details (GitHub Issue + index.json)")
+  .description("Show feedback details (GitHub Issue + index.yaml)")
   .argument("<issue-number>", "GitHub issue number")
   .option("--json", "Output as JSON")
   .action(async (issueNumberStr: string, options: { json?: boolean }) => {

--- a/packages/cli/src/commands/feedback/sync.ts
+++ b/packages/cli/src/commands/feedback/sync.ts
@@ -4,8 +4,8 @@ import { syncFromGitHub, syncToGitHub } from "../../services/feedback-sync-servi
 import { handleError } from "../../utils/error-handler.js";
 
 export const syncCommand = new Command("sync")
-  .description("Sync GitHub Issues with feedback label to index.json")
-  .option("--from-local", "Sync from index.json to GitHub")
+  .description("Sync GitHub Issues with feedback label to index.yaml")
+  .option("--from-local", "Sync from index.yaml to GitHub")
   .option("--json", "Output as JSON")
   .action(async (options: { fromLocal?: boolean; json?: boolean }) => {
     try {
@@ -18,8 +18,8 @@ export const syncCommand = new Command("sync")
         console.log(JSON.stringify({ synced: count }));
       } else {
         const direction = options.fromLocal
-          ? "index.json → GitHub"
-          : "GitHub → index.json";
+          ? "index.yaml → GitHub"
+          : "GitHub → index.yaml";
         console.log(chalk.green(`✓ Synced ${count} feedbacks (${direction})`));
       }
     } catch (error) {

--- a/packages/cli/src/commands/req/approve.test.ts
+++ b/packages/cli/src/commands/req/approve.test.ts
@@ -88,7 +88,7 @@ describe("approveCommand", () => {
         version: "1.0.0",
         status: "draft",
         title: "Test Requirement",
-        files: [".reqord/requirements/req-000001.json"],
+        files: [".reqord/requirements/req-000001.yaml"],
       },
       requirementHandler,
       { dryRun: undefined }
@@ -165,7 +165,7 @@ describe("approveCommand", () => {
       version: "2.1.0",
       status: "draft",
       title: "Another Requirement",
-      files: [".reqord/requirements/req-000042.json"],
+      files: [".reqord/requirements/req-000042.yaml"],
     });
     expect(callArgs[2]).toBe(requirementHandler);
     // Check dryRun is falsy (undefined or false)

--- a/packages/cli/src/commands/req/approve.ts
+++ b/packages/cli/src/commands/req/approve.ts
@@ -25,7 +25,7 @@ export const approveCommand = new Command("approve")
         version: requirement.version,
         status: requirement.status,
         title: requirement.title,
-        files: [`${REQORD_DIR}/${REQUIREMENTS_DIR}/${requirement.id}.json`],
+        files: [`${REQORD_DIR}/${REQUIREMENTS_DIR}/${requirement.id}.yaml`],
       };
 
       const result = await startApproval(cwd, target, requirementHandler, {

--- a/packages/cli/src/commands/spec/approve.test.ts
+++ b/packages/cli/src/commands/spec/approve.test.ts
@@ -143,7 +143,7 @@ describe("specApproveCommand", () => {
         status: "draft",
         title: "Specification spec-000001 (Test Requirement)",
         files: [
-          ".reqord/specifications/spec-000001.json",
+          ".reqord/specifications/spec-000001.yaml",
           ".reqord/specifications/spec-000001/design.md",
         ],
       },
@@ -298,7 +298,7 @@ describe("specApproveCommand", () => {
       status: "draft",
       title: "Specification spec-000042 (Feature X)",
       files: [
-        ".reqord/specifications/spec-000042.json",
+        ".reqord/specifications/spec-000042.yaml",
         ".reqord/specifications/spec-000042/design.md",
       ],
     });

--- a/packages/cli/src/commands/spec/approve.ts
+++ b/packages/cli/src/commands/spec/approve.ts
@@ -62,7 +62,7 @@ export const specApproveCommand = new Command("approve")
         status: specification.status,
         title: `Specification ${specification.id} (${requirement.title})`,
         files: [
-          `${REQORD_DIR}/${SPECIFICATIONS_DIR}/${specification.id}.json`,
+          `${REQORD_DIR}/${SPECIFICATIONS_DIR}/${specification.id}.yaml`,
           `${REQORD_DIR}/${SPECIFICATIONS_DIR}/${specification.id}/design.md`,
         ],
       };

--- a/packages/cli/src/services/approval-service.test.ts
+++ b/packages/cli/src/services/approval-service.test.ts
@@ -25,7 +25,7 @@ function makeApprovalTarget(overrides: Partial<ApprovalTarget> = {}): ApprovalTa
     version: "1.0.0",
     status: "draft",
     title: "Test Requirement",
-    files: [".reqord/requirements/req-000011.json"],
+    files: [".reqord/requirements/req-000011.yaml"],
     ...overrides,
   };
 }
@@ -88,7 +88,7 @@ describe("startApproval", () => {
     expect(mockHandler.saveCurrentApproval).toHaveBeenCalledWith("/test/cwd", target, "2.0.0");
 
     // Verify git operations
-    expect(gitRepo.add).toHaveBeenCalledWith("/test/cwd", [".reqord/requirements/req-000011.json"]);
+    expect(gitRepo.add).toHaveBeenCalledWith("/test/cwd", [".reqord/requirements/req-000011.yaml"]);
     expect(gitRepo.commit).toHaveBeenCalledWith("/test/cwd", "chore(reqord): request approval for req-000011");
     expect(gitRepo.push).toHaveBeenCalledWith("/test/cwd", "reqord/req-000011-approve-v1.0.0");
 

--- a/packages/cli/src/services/context-service.test.ts
+++ b/packages/cli/src/services/context-service.test.ts
@@ -15,6 +15,8 @@ vi.mock("../repositories/file-system.js", () => ({
   exists: vi.fn(),
   readJSON: vi.fn(),
   writeJSON: vi.fn(),
+  readYAML: vi.fn(),
+  writeYAML: vi.fn(),
   mkdirp: vi.fn(),
   readdirFiles: vi.fn(),
   joinPath: vi.fn((...args: string[]) => args.join("/")),
@@ -32,9 +34,9 @@ function makeContext(overrides: Partial<ProjectContext> = {}): ProjectContext {
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
     files: {
-      product: { path: "context/product.json", format: "json" },
-      technical: { structured: "context/technical.json" },
-      structure: { structured: "context/structure.json" },
+      product: { path: "context/product.yaml", format: "yaml" },
+      technical: { structured: "context/technical.yaml" },
+      structure: { structured: "context/structure.yaml" },
       domain: [],
     },
     ...overrides,
@@ -50,7 +52,7 @@ describe("updateContext", () => {
     vi.mocked(contextRepo.load).mockResolvedValue(null);
 
     await expect(updateContext("/cwd", {})).rejects.toThrow(
-      "context.json not found. Run 'reqord context init' first.",
+      "context.yaml not found. Run 'reqord context init' first.",
     );
   });
 
@@ -87,7 +89,7 @@ describe("updateContext", () => {
     expect(result.after.createdAt).toBe(ctx.createdAt);
   });
 
-  it("product.jsonをパッチ更新できる", async () => {
+  it("product.yamlをパッチ更新できる", async () => {
     const ctx = makeContext();
     vi.mocked(contextRepo.load).mockResolvedValue(ctx);
     vi.mocked(contextRepo.save).mockResolvedValue(undefined);
@@ -117,7 +119,7 @@ describe("updateContext", () => {
     expect(result.updatedFiles).toContain("product");
   });
 
-  it("technical.jsonをパッチ更新できる", async () => {
+  it("technical.yamlをパッチ更新できる", async () => {
     const ctx = makeContext();
     vi.mocked(contextRepo.load).mockResolvedValue(ctx);
     vi.mocked(contextRepo.save).mockResolvedValue(undefined);
@@ -145,7 +147,7 @@ describe("updateContext", () => {
     expect(result.updatedFiles).toContain("technical");
   });
 
-  it("structure.jsonをパッチ更新できる", async () => {
+  it("structure.yamlをパッチ更新できる", async () => {
     const ctx = makeContext();
     vi.mocked(contextRepo.load).mockResolvedValue(ctx);
     vi.mocked(contextRepo.save).mockResolvedValue(undefined);

--- a/packages/cli/src/services/context-service.ts
+++ b/packages/cli/src/services/context-service.ts
@@ -3,7 +3,7 @@ import { CONTEXT_DIR, DOMAIN_DIR } from "@reqord/shared";
 import * as contextRepo from "../repositories/project-context.js";
 import * as fs from "../repositories/file-system.js";
 
-const CONTEXT_NOT_FOUND = "context.json not found. Run 'reqord context init' first.";
+const CONTEXT_NOT_FOUND = "context.yaml not found. Run 'reqord context init' first.";
 
 export interface InitContextOptions {
   id: string;
@@ -16,7 +16,7 @@ export async function initContext(
   options: InitContextOptions,
 ): Promise<ProjectContext> {
   if (await contextRepo.contextExists(cwd)) {
-    throw new Error("context.json already exists.");
+    throw new Error("context.yaml already exists.");
   }
 
   const now = new Date().toISOString();
@@ -28,9 +28,9 @@ export async function initContext(
     createdAt: now,
     updatedAt: now,
     files: {
-      product: { path: `${CONTEXT_DIR}/product.json`, format: "json" },
-      technical: { structured: `${CONTEXT_DIR}/technical.json` },
-      structure: { structured: `${CONTEXT_DIR}/structure.json` },
+      product: { path: `${CONTEXT_DIR}/product.yaml`, format: "yaml" },
+      technical: { structured: `${CONTEXT_DIR}/technical.yaml` },
+      structure: { structured: `${CONTEXT_DIR}/structure.yaml` },
       domain: [],
     },
   };
@@ -41,15 +41,15 @@ export async function initContext(
   const contextDir = fs.getReqordDir(cwd, CONTEXT_DIR);
 
   const templateFiles: Array<[string, unknown]> = [
-    ["product.json", { name: options.name, vision: "", goals: [], targetUsers: [] }],
-    ["technical.json", { stack: {}, constraints: [], decisions: [] }],
-    ["structure.json", { modules: [], layers: [] }],
+    ["product.yaml", { name: options.name, vision: "", goals: [], targetUsers: [] }],
+    ["technical.yaml", { stack: {}, constraints: [], decisions: [] }],
+    ["structure.yaml", { modules: [], layers: [] }],
   ];
 
   for (const [filename, defaultContent] of templateFiles) {
     const filePath = fs.joinPath(contextDir, filename);
     if (!(await fs.exists(filePath))) {
-      await fs.writeJSON(filePath, defaultContent);
+      await fs.writeYAML(filePath, defaultContent);
     }
   }
 
@@ -80,7 +80,7 @@ export async function showContext(cwd: string): Promise<ShowContextResult> {
   async function resolveFileStatus(fileRef: unknown): Promise<{ exists: boolean; content?: unknown }> {
     const fullPath = fs.getReqordDir(cwd, resolveFilePath(fileRef));
     const fileExists = await fs.exists(fullPath);
-    const content = fileExists ? await safeReadJSON(fullPath) : undefined;
+    const content = fileExists ? await safeReadYAML(fullPath) : undefined;
     return { exists: fileExists, content };
   }
 
@@ -155,9 +155,9 @@ export async function updateContext(
   return { before, after, updatedFiles };
 }
 
-async function safeReadJSON(path: string): Promise<unknown> {
+async function safeReadYAML(path: string): Promise<unknown> {
   try {
-    return await fs.readJSON(path);
+    return await fs.readYAML(path);
   } catch {
     return null;
   }

--- a/packages/cli/src/services/feedback-service.test.ts
+++ b/packages/cli/src/services/feedback-service.test.ts
@@ -187,7 +187,7 @@ describe("showFeedback", () => {
     vi.clearAllMocks();
   });
 
-  it("index.jsonとGitHub IssueのマージデータをReturn", async () => {
+  it("index.yamlとGitHub IssueのマージデータをReturn", async () => {
     const feedback = makeFeedbackEntry({ githubIssue: 17 });
     mockFeedbackRepo.loadIndex.mockResolvedValue(makeFeedbackIndex([feedback]));
     const issue = makeGitHubIssue({ number: 17 });
@@ -198,11 +198,11 @@ describe("showFeedback", () => {
     expect(result).toEqual({ feedback, issue });
   });
 
-  it("index.jsonに存在しないissueでエラーを投げる", async () => {
+  it("index.yamlに存在しないissueでエラーを投げる", async () => {
     mockFeedbackRepo.loadIndex.mockResolvedValue(makeFeedbackIndex([]));
 
     await expect(showFeedback("/test/cwd", 99)).rejects.toThrow(
-      "Feedback for issue #99 not found in index.json",
+      "Feedback for issue #99 not found in index.yaml",
     );
   });
 
@@ -223,7 +223,7 @@ describe("linkToRequirement", () => {
     vi.clearAllMocks();
   });
 
-  it("index.jsonのlinkedTo.requirementsに追加する", async () => {
+  it("index.yamlのlinkedTo.requirementsに追加する", async () => {
     const feedback = makeFeedbackEntry({ githubIssue: 17 });
     mockFeedbackRepo.loadIndex.mockResolvedValue(makeFeedbackIndex([feedback]));
     const requirement = makeRequirement({ id: "req-000001" });
@@ -346,7 +346,7 @@ describe("linkToRequirement", () => {
     expect(savedReq).toBeUndefined();
   });
 
-  it("index.jsonにfeedbackがない場合は新規作成する", async () => {
+  it("index.yamlにfeedbackがない場合は新規作成する", async () => {
     mockFeedbackRepo.loadIndex.mockResolvedValue(makeFeedbackIndex([]));
     const requirement = makeRequirement({ id: "req-000001" });
     mockReqRepo.findByIdOrThrow.mockResolvedValue(requirement);
@@ -412,7 +412,7 @@ describe("linkWithNewRequirement", () => {
     });
   });
 
-  it("index.jsonのlinkedTo.createdRequirementsに追加する", async () => {
+  it("index.yamlのlinkedTo.createdRequirementsに追加する", async () => {
     mockFeedbackRepo.loadIndex.mockResolvedValue(makeFeedbackIndex([]));
     const issue = makeGitHubIssue({ number: 17, title: "Test" });
     mockGithubClient.getIssue.mockResolvedValue(issue);
@@ -454,7 +454,7 @@ describe("linkToSpecification", () => {
     vi.clearAllMocks();
   });
 
-  it("index.jsonのlinkedTo.specificationsに追加する", async () => {
+  it("index.yamlのlinkedTo.specificationsに追加する", async () => {
     const feedback = makeFeedbackEntry({ githubIssue: 17 });
     mockFeedbackRepo.loadIndex.mockResolvedValue(makeFeedbackIndex([feedback]));
     const specification = makeSpecification({ id: "spec-000001" });
@@ -550,7 +550,7 @@ describe("closeFeedback", () => {
     vi.clearAllMocks();
   });
 
-  it("index.jsonのstatusをclosedに更新する", async () => {
+  it("index.yamlのstatusをclosedに更新する", async () => {
     const feedback = makeFeedbackEntry({ githubIssue: 17, status: "open" });
     mockFeedbackRepo.loadIndex.mockResolvedValue(makeFeedbackIndex([feedback]));
 

--- a/packages/cli/src/services/feedback-service.ts
+++ b/packages/cli/src/services/feedback-service.ts
@@ -63,7 +63,7 @@ export async function showFeedback(
 
   if (!feedback) {
     throw new Error(
-      `Feedback for issue #${issueNumber} not found in index.json. Run 'reqord feedback sync' first.`,
+      `Feedback for issue #${issueNumber} not found in index.yaml. Run 'reqord feedback sync' first.`,
     );
   }
 
@@ -78,7 +78,7 @@ export async function linkToRequirement(
   // Verify requirement exists
   const requirement = await reqRepo.findByIdOrThrow(cwd, options.requirementId);
 
-  // Update index.json
+  // Update index.yaml
   const index = await feedbackRepo.loadIndex(cwd);
   const feedback = getOrCreateFeedback(index, options.issueNumber, options);
 
@@ -137,7 +137,7 @@ export async function linkWithNewRequirement(
   requirement.origin = { feedbackIssue: options.issueNumber };
   await reqRepo.save(cwd, requirement);
 
-  // Update index.json
+  // Update index.yaml
   const index = await feedbackRepo.loadIndex(cwd);
   const feedback = getOrCreateFeedback(index, options.issueNumber, options);
   feedback.linkedTo.createdRequirements.push(newId);
@@ -165,7 +165,7 @@ export async function linkToSpecification(
   // Verify specification exists
   const specification = await specRepo.findByIdOrThrow(cwd, options.specificationId);
 
-  // Update index.json
+  // Update index.yaml
   const index = await feedbackRepo.loadIndex(cwd);
   const feedback = getOrCreateFeedback(index, options.issueNumber, options);
 

--- a/packages/cli/src/utils/id-generator.ts
+++ b/packages/cli/src/utils/id-generator.ts
@@ -6,7 +6,7 @@ async function generateNextPrefixedId(
   dir: string,
   prefix: string,
 ): Promise<string> {
-  const pattern = new RegExp(`^${prefix}-(\\d{6})\\.json$`);
+  const pattern = new RegExp(`^${prefix}-(\\d{6})\\.yaml$`);
   const targetDir = fs.getReqordDir(cwd, dir);
   const files = await fs.readdirFiles(targetDir, (name) => pattern.test(name));
 

--- a/packages/web/src/lib/id-generator.ts
+++ b/packages/web/src/lib/id-generator.ts
@@ -4,12 +4,12 @@ import * as fs from "./file-system";
 export async function generateNextId(cwd: string): Promise<string> {
   const reqDir = fs.joinPath(cwd, REQORD_DIR, REQUIREMENTS_DIR);
   const files = await fs.readdirFiles(reqDir, (name) =>
-    /^req-\d{6}\.json$/.test(name),
+    /^req-\d{6}\.yaml$/.test(name),
   );
 
   let maxNum = 0;
   for (const file of files) {
-    const match = file.match(/^req-(\d{6})\.json$/);
+    const match = file.match(/^req-(\d{6})\.yaml$/);
     if (match) {
       const num = parseInt(match[1], 10);
       if (num > maxNum) {


### PR DESCRIPTION
## Summary

- Updated all remaining `.json` references to `.yaml` across 17 files after the YAML migration (req-000027)
- Fixed critical ID generation bug where new requirements/specifications would always get ID `000001`
- Fixed approval PR file lists, context initialization, and all user-facing messages

## Changes

**Critical bug fixes (2 files):**
- `id-generator.ts` (CLI + Web) — regex patterns now match `.yaml` files for correct ID generation

**Functional fixes (3 files):**
- `req/approve.ts`, `spec/approve.ts` — approval PR file lists reference `.yaml`
- `context-service.ts` — `initContext` creates `.yaml` files with `writeYAML`, `showContext` reads with `readYAML`

**UX message fixes (6 files):**
- `context/init.ts` — console output shows `.yaml` filenames
- `context/update.ts` — option descriptions reference `.yaml`
- `feedback/show.ts`, `close.ts`, `list.ts`, `sync.ts` — descriptions and output updated

**Error message/comment fixes (1 file):**
- `feedback-service.ts` — error messages and comments reference `index.yaml`

**Test updates (5 files):**
- All corresponding test expectations, mocks, and description texts updated

## Test plan

- [x] All 702 tests pass (67 test files)
- [x] TypeScript type-check passes for all packages
- [x] Comprehensive grep confirms no remaining `.json` refs for reqord data files

🤖 Generated with [Claude Code](https://claude.com/claude-code)