### PR TITLE
[Approval] req-000023 v2.0.0: Feedback管理 - flagライフサイクル追加

### DIFF
--- a/.reqord/requirements/req-000023.yaml
+++ b/.reqord/requirements/req-000023.yaml
@@ -1,7 +1,7 @@
 id: req-000023
 version: 2.0.0
 title: Feedback管理 (GitHub Issue連携)
-status: draft
+status: pending_approval
 priority: medium
 createdAt: 2026-02-09T10:00:00Z
 updatedAt: 2026-02-09T11:57:46Z
@@ -10,6 +10,10 @@ versionHistory:
     status: draft
     changedAt: 2026-02-11T12:00:00Z
     summary: "flagライフサイクル管理を追加: flagは一時的マーカーとして対応完了後に削除、index.yamlがトレーサビリティのSOT"
+  - version: 2.0.0
+    status: pending_approval
+    changedAt: 2026-02-11T13:00:00Z
+    summary: Status changed from draft to pending_approval
 files:
   description: requirements/req-000023/description.md
   supplementary: []


### PR DESCRIPTION
## Summary

req-000023 (Feedback管理) v2.0.0 の承認申請です。

## 変更概要（v1.1.0 → v2.0.0）

### 追加された設計原則

- **flagは一時的なアクションマーカー**: 対応完了後に削除する
- **index.yamlがトレーサビリティのSource of Truth**: feedback issue → req/specの紐付けを永続的に保持
- flagにstatusは持たせない（index.yamlとの二重管理回避）

### 追加された成功基準

- `reqord feedback resolve <req-id> --issue <number>` でflag削除 + index.yaml status更新
- flags配列が空でないreq/specへの承認操作時に警告表示

### v1.1.0からの既存成功基準（実装済み）

- feedback sync / list / show / link / close コマンド
- FeedbackIndex Zodスキーマバリデーション
- type/severityオプション

## レビュー観点

- [ ] flagのライフサイクル（追加→反映→削除）の設計は妥当か
- [ ] index.yamlをSOTとするトレーサビリティ設計は十分か
- [ ] 新しい成功基準の粒度・表現は適切か

🤖 Generated with [Claude Code](https://claude.com/claude-code)