### PR TITLE
[Reqord] Revert spec-000028 to draft: spec-000028

### DIFF
--- a/.reqord/specifications/spec-000028.yaml
+++ b/.reqord/specifications/spec-000028.yaml
@@ -1,12 +1,13 @@
 id: spec-000028
 requirementId: req-000023
-title: 'Feedback管理 (GitHub Issue連携)'
+title: Feedback管理 (GitHub Issue連携)
 requirementVersion: '3.0'
 version: '2.0'
-status: implemented
+status: draft
 createdAt: 2026-02-09T05:48:42.351Z
-updatedAt: 2026-02-12T00:00:00Z
+updatedAt: 2026-02-16T06:29:00.065Z
 versionHistory: []
 files:
   design: specifications/spec-000028/design.md
   supplementary: []
+flags: []


### PR DESCRIPTION
## 仕様差し戻し

| フィールド | 値 |
|-----------|------|
| ID | spec-000028 |
| タイトル | spec-000028 |
| バージョン | 2.0 |
| 変更前ステータス | implemented |

### 影響範囲
以下の要件がこの仕様の親要件に依存しています:
なし（他の要件に影響はありません）

### 変更内容
status: implemented → draft

> このPRをマージすると、仕様のステータスが `draft` に差し戻されます。