### PR TITLE
[Reqord] Revert spec-000027 to draft: spec-000027

### DIFF
--- a/.reqord/specifications/spec-000027.yaml
+++ b/.reqord/specifications/spec-000027.yaml
@@ -1,11 +1,11 @@
 id: spec-000027
 requirementId: req-000023
-title: 'Feedback管理 (GitHub Issue連携)'
+title: Feedback管理 (GitHub Issue連携)
 requirementVersion: '3.0'
 version: '2.0'
-status: implemented
+status: draft
 createdAt: 2026-02-09T05:48:38.643Z
-updatedAt: 2026-02-12T00:00:00Z
+updatedAt: 2026-02-16T06:29:09.273Z
 versionHistory: []
 files:
   design: specifications/spec-000027/design.md


### PR DESCRIPTION
## 仕様差し戻し

| フィールド | 値 |
|-----------|------|
| ID | spec-000027 |
| タイトル | spec-000027 |
| バージョン | 2.0 |
| 変更前ステータス | implemented |

### 影響範囲
以下の要件がこの仕様の親要件に依存しています:
なし（他の要件に影響はありません）

### 変更内容
status: implemented → draft

> このPRをマージすると、仕様のステータスが `draft` に差し戻されます。