### PR TITLE
[Reqord] Revert req-000023 to draft: Feedback管理 (GitHub Issue連携)

### DIFF
--- a/.reqord/requirements/req-000023.yaml
+++ b/.reqord/requirements/req-000023.yaml
@@ -1,10 +1,10 @@
 id: req-000023
 version: '3.0'
 title: Feedback管理 (GitHub Issue連携)
-status: implemented
+status: draft
 priority: medium
 createdAt: 2026-02-09T10:00:00Z
-updatedAt: 2026-02-11T14:30:00Z
+updatedAt: 2026-02-16T06:29:17.984Z
 versionHistory:
   - version: 2.0.0
     status: draft
@@ -88,10 +88,4 @@ flags:
     createdAt: 2026-02-13T15:49:34.208Z
     relatedIssues:
       - 224
-    severity: medium
-  - type: feedback-review
-    reason: 'Feedback from issue #223'
-    createdAt: 2026-02-13T15:49:37.666Z
-    relatedIssues:
-      - 223
     severity: medium


### PR DESCRIPTION
## 要件差し戻し

| フィールド | 値 |
|-----------|------|
| ID | req-000023 |
| タイトル | Feedback管理 (GitHub Issue連携) |
| バージョン | 3.0 |
| 変更前ステータス | implemented |

### 影響範囲
以下の要件がこの要件に依存しています:
なし（他の要件に影響はありません）

### 変更内容
status: implemented → draft

> このPRをマージすると、要件のステータスが `draft` に差し戻されます。