### PR TITLE
chore(plugin): remove disable-model-invocation from all reqord skills

### DIFF
--- a/plugins/reqord/skills/design/SKILL.md
+++ b/plugins/reqord/skills/design/SKILL.md
@@ -2,7 +2,6 @@
 name: design
 description: Specification設計書作成。Requirementの内容・ProjectContext・既存コード実装状況を基にdesign.md（技術設計書）を生成する。Generate technical design documents (design.md) for specifications. Use when creating architecture blueprints, planning implementation, or designing features.
 argument-hint: "[spec-id...|req-id...|--all] (省略時は対話選択、複数指定可)"
-disable-model-invocation: true
 ---
 
 # Specification設計書作成コマンド

--- a/plugins/reqord/skills/dev/SKILL.md
+++ b/plugins/reqord/skills/dev/SKILL.md
@@ -2,8 +2,9 @@
 name: dev
 description: Specificationのdesign.mdに基づく機能開発。実装計画の生成からTDD実装・レビューまでを一貫して行う。planサブコマンドで計画のみも可能。Feature development from design.md through TDD implementation and code review. Use when implementing features, coding specifications, or running the full dev cycle.
 argument-hint: <spec-id> [plan]
-disable-model-invocation: true
 ---
+
+> **ユーザー確認必須**: このスキルはコード生成・ファイル変更を伴います。自律実行時は実装開始前にユーザーの承認を得てください。
 
 # Specification機能開発コマンド
 

--- a/plugins/reqord/skills/feedback/SKILL.md
+++ b/plugins/reqord/skills/feedback/SKILL.md
@@ -2,8 +2,9 @@
 name: feedback
 description: Feedback運用（同期・分類・リンク・クローズ・フラグ解消）。GitHub Issueとして報告されたフィードバックの取り込みワークフローを実行する。Manage feedback lifecycle - sync GitHub issues, classify, link to requirements/specifications, close, and resolve flags. Use when processing issues, triaging bugs, or linking feedback.
 argument-hint: "[issue-number...] (省略時は未処理一覧から選択)"
-disable-model-invocation: true
 ---
+
+> **ユーザー確認必須**: このスキルはGitHub Issue操作（クローズ・コメント）を伴います。自律実行時は操作内容をユーザーに提示し、承認を得てから実行してください。
 
 # Feedback運用コマンド
 

--- a/plugins/reqord/skills/git/SKILL.md
+++ b/plugins/reqord/skills/git/SKILL.md
@@ -2,8 +2,9 @@
 name: git
 description: Specification参照付きのGit操作（ブランチ作成・コミット・PR）。spec-idベースの命名規則とトレーサビリティ情報をPRに含める。Spec-aware Git operations - create branches, commit, push, and create PRs with automatic traceability. Use when branching for a specification, committing implementation, or creating pull requests.
 argument-hint: "<branch|commit> <spec-id> (branch: [type], commit: [message])"
-disable-model-invocation: true
 ---
+
+> **ユーザー確認必須**: このスキルはGit操作（ブランチ作成・コミット・プッシュ・PR作成）を伴います。自律実行時は操作内容をユーザーに提示し、承認を得てから実行してください。
 
 # reqord-git: Specification連携Git操作
 

--- a/plugins/reqord/skills/refine/SKILL.md
+++ b/plugins/reqord/skills/refine/SKILL.md
@@ -2,7 +2,6 @@
 name: refine
 description: 要件詳細化。バリデーション結果・既存コード実装状況・ドメイン知識を基にRequirementのSMART品質スコアを向上させる。Refine and improve requirement quality by analyzing SMART scores, validation issues, and existing code. Use when improving requirements, fixing validation warnings, or enhancing success criteria.
 argument-hint: "[req-id...] (省略時は対話選択、複数指定可)"
-disable-model-invocation: true
 ---
 
 # 要件詳細化コマンド

--- a/plugins/reqord/skills/setup/SKILL.md
+++ b/plugins/reqord/skills/setup/SKILL.md
@@ -2,8 +2,9 @@
 name: setup
 description: Reqordプラグインの環境セットアップと前提条件チェック。初回利用時に実行し、必要なツールの可用性を確認する。Verify environment prerequisites for the Reqord plugin - CLI tools, GitHub authentication, and project initialization. Run on first use or when troubleshooting.
 argument-hint: "[--check] (省略時はフルセットアップ、--checkは確認のみ)"
-disable-model-invocation: true
 ---
+
+> **ユーザー確認必須**: このスキルは環境設定の変更を伴います。自律実行時はセットアップ内容をユーザーに提示し、承認を得てから実行してください。
 
 # Reqordプラグイン環境セットアップ
 

--- a/plugins/reqord/skills/status/SKILL.md
+++ b/plugins/reqord/skills/status/SKILL.md
@@ -2,7 +2,6 @@
 name: status
 description: Reqordの要件・仕様の実装進捗ダッシュボードを表示する。Show requirement and specification implementation progress dashboard. Use when checking project status, finding next tasks, or reviewing progress.
 argument-hint: "[approved|implemented|all] (デフォルト: approved)"
-disable-model-invocation: true
 ---
 
 # Reqord進捗ダッシュボード

--- a/plugins/reqord/skills/verify/SKILL.md
+++ b/plugins/reqord/skills/verify/SKILL.md
@@ -2,8 +2,9 @@
 name: verify
 description: Specificationの実装検証・トレーサビリティ確認・完了処理。紐づくRequirementのsuccess criteriaに対する充足確認からステータス更新までをカバーする。Validate implementation against success criteria, trace requirement-to-code links, and mark specifications as complete. Use when verifying features, checking traceability, or completing implementation.
 argument-hint: "<validate|trace|done> <id> (validate/done: spec-id, trace: spec-id|req-id)"
-disable-model-invocation: true
 ---
+
+> **ユーザー確認必須**: `done`サブコマンドはSpecificationステータスを変更します。自律実行時はステータス変更前にユーザーの承認を得てください。
 
 # reqord-verify: 実装検証・トレーサビリティ確認
 


### PR DESCRIPTION
## Summary

- 全8スキルから `disable-model-invocation: true` を削除し、Claudeが自律的にスキルを呼び出せるようにした
- 副作用のある操作（dev/git/verify/feedback/setup）には、ユーザー確認を求めるガードレールコメントを追記

## 変更詳細

| スキル | 変更内容 |
|---|---|
| `status` / `refine` / `design` | フラグ削除のみ（副作用なし） |
| `dev` | フラグ削除 + 実装開始前のユーザー承認指示を追加 |
| `git` | フラグ削除 + Git操作前のユーザー承認指示を追加 |
| `verify` | フラグ削除 + `done`サブコマンドのステータス変更前のユーザー承認指示を追加 |
| `feedback` | フラグ削除 + GitHub Issue操作前のユーザー承認指示を追加 |
| `setup` | フラグ削除 + 環境変更前のユーザー承認指示を追加 |

## 背景

`disable-model-invocation: true` はClaude自身がスキルを呼び出せなくなる設定。
自律的な開発フロー（reqord:status → reqord:design → reqord:dev の連鎖実行）を可能にするため削除。
副作用のある操作はスキル内の指示文でガードレールを設け、Human-in-the-loopを維持する。

## Test plan

- [ ] `disable-model-invocation` が全スキルから削除されていることを確認
- [ ] 副作用スキルにガードレールコメントが追加されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)