### PR TITLE
chore(plugin): add human-in-the-loop rule for spec approval

### DIFF
--- a/plugins/reqord/skills/context/SKILL.md
+++ b/plugins/reqord/skills/context/SKILL.md
@@ -189,7 +189,13 @@ context.yamlの`files`フィールドが参照するファイルをReadツール
 Phase 0: 状況把握
   /reqord:status → 進捗確認、次に着手すべきspecを特定
 
-Phase 1: 計画・開発
+Phase 0.5: Specification承認（Human-in-the-loop）
+  /reqord:design <spec-id> → design.md作成
+  reqord spec approve <spec-id> → 承認依頼PR作成
+  [PR承認・マージを待機] → status: approved に遷移
+  ※ 手動でYAMLのstatusを変更してはならない
+
+Phase 1: 計画・開発（specがapprovedであること）
   /check-branch → /reqord:git branch <spec-id>
   → /reqord:dev <spec-id> → /test → /lint
 

--- a/plugins/reqord/skills/dev/SKILL.md
+++ b/plugins/reqord/skills/dev/SKILL.md
@@ -32,6 +32,17 @@ $ARGUMENTSを解析してサブコマンドを振り分ける。
 2. `reqord spec show <spec-id> --json` で存在確認
 3. specのstatusが `approved` であることを確認（`draft`なら承認を促す、`implemented`なら再実装の確認）
 
+### Human-in-the-loop: 承認PRの待機
+
+specのstatusが `draft` の場合、**手動でYAMLファイルを編集してstatusを変更してはならない**。
+承認フローを遵守し、以下の手順で進める:
+
+1. `reqord spec approve <spec-id>` で承認依頼PRを作成する（未作成の場合）
+2. 承認PRがマージされるまで待機する
+3. PRがマージされてstatusが `approved` に遷移したことを確認してから実装に進む
+
+承認PRが既に作成済みでマージ待ちの場合は、PR URLを表示してユーザーにマージを促す。
+
 ---
 
 ## Step 1: コンテキスト読み込み


### PR DESCRIPTION
## Summary

- Reqordプラグインのスキルに、Specification承認フローのhuman-in-the-loopルールを追記
- 手動でYAMLのstatusを変更することを禁止し、PR承認フローを遵守するよう明記

## Changes

- **`plugins/reqord/skills/dev/SKILL.md`**: Step 0バリデーションに承認PR待機ルールを追加
- **`plugins/reqord/skills/context/SKILL.md`**: ワークフローにPhase 0.5（Specification承認）ステップを追加

## Test plan

- [ ] `/reqord:dev` でdraft状態のspecを指定した際に、承認フローを案内することを確認
- [ ] ワークフローの記載が正しいことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)