### PR TITLE
[Reqord] Revert req-000005 to draft: Requirement/Specificationバージョン管理

### DIFF
--- a/.reqord/requirements/req-000005.yaml
+++ b/.reqord/requirements/req-000005.yaml
@@ -1,7 +1,7 @@
 id: req-000005
 version: '5.0'
 title: Requirement/Specificationバージョン管理
-status: implemented
+status: draft
 priority: medium
 createdAt: 2026-02-07T10:00:00Z
 updatedAt: 2026-02-20T14:13:19.911Z
@@ -68,4 +68,10 @@ currentApproval:
   prNumber: 271
   prUrl: https://github.com/kicchann/reqord/pull/271
   approvedBy: []
-flags: []
+flags:
+  - type: feedback-review
+    reason: 'Feedback from issue #411'
+    createdAt: 2026-02-20T13:52:30.190Z
+    relatedIssues:
+      - 411
+    severity: low


### PR DESCRIPTION
## 要件差し戻し

| フィールド | 値 |
|-----------|------|
| ID | req-000005 |
| タイトル | Requirement/Specificationバージョン管理 |
| バージョン | 4.0 |
| 変更前ステータス | implemented |

### 影響範囲
以下の要件がこの要件に依存しています:
なし（他の要件に影響はありません）

### 変更内容
status: implemented → draft

> このPRをマージすると、要件のステータスが `draft` に差し戻されます。