### PR TITLE
[Reqord] Revert spec-000011 to draft: spec-000011

### DIFF
--- a/.reqord/specifications/spec-000011.yaml
+++ b/.reqord/specifications/spec-000011.yaml
@@ -3,7 +3,7 @@ requirementId: req-000011
 title: Requirement承認フロー (GitHub PR連携)
 requirementVersion: '5.0'
 version: '2.0'
-status: implemented
+status: draft
 createdAt: 2026-02-08T14:08:07.471Z
 updatedAt: 2026-02-20T14:13:22.338Z
 versionHistory:
@@ -30,7 +30,13 @@ versionHistory:
 files:
   design: specifications/spec-000011/design.md
   supplementary: []
-flags: []
+flags:
+  - type: feedback-review
+    reason: 'Feedback from issue #410'
+    createdAt: 2026-02-20T13:52:38.053Z
+    relatedIssues:
+      - 410
+    severity: low
 currentApproval:
   version: '1.0'
   phase: specification


### PR DESCRIPTION
## 仕様差し戻し

| フィールド | 値 |
|-----------|------|
| ID | spec-000011 |
| タイトル | spec-000011 |
| バージョン | 1.0 |
| 変更前ステータス | implemented |

### 影響範囲
以下の要件がこの仕様の親要件に依存しています:
- req-000012
- req-000015

### 変更内容
status: implemented → draft

> このPRをマージすると、仕様のステータスが `draft` に差し戻されます。