### PR TITLE
chore(reqord): link and resolve feedback #410 #411

### DIFF
--- a/.reqord/feedback/index.yaml
+++ b/.reqord/feedback/index.yaml
@@ -399,7 +399,7 @@ feedbacks:
         requirements:
           - req-000015
         specifications: []
-    syncedAt: 2026-02-18T02:38:42.790Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 273
     linkedTo:
@@ -407,7 +407,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T02:38:42.790Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 335
     linkedTo:
@@ -415,7 +415,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T02:38:42.790Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 328
     linkedTo:
@@ -423,7 +423,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T02:38:42.790Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 327
     linkedTo:
@@ -431,7 +431,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T02:38:42.790Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 398
     type: improvement
@@ -441,7 +441,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T14:40:54.671Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 399
     type: improvement
@@ -451,7 +451,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T14:41:04.220Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 400
     type: improvement
@@ -461,7 +461,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T14:41:13.656Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 401
     type: improvement
@@ -471,7 +471,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T14:41:24.029Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 402
     type: improvement
@@ -481,7 +481,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T14:46:49.595Z
+    syncedAt: 2026-02-20T14:30:39.096Z
     status: open
   - githubIssue: 403
     type: requirement-gap
@@ -491,7 +491,7 @@ feedbacks:
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-18T14:46:53.590Z
+    syncedAt: 2026-02-20T14:30:39.095Z
     status: open
   - githubIssue: 410
     type: spec-mismatch
@@ -499,17 +499,29 @@ feedbacks:
     linkedTo:
       requirements: []
       createdRequirements: []
-      specifications: []
+      specifications:
+        - spec-000015
+        - spec-000011
       createdSpecifications: []
-    syncedAt: 2026-02-20T12:29:37.690Z
-    status: open
+      resolved:
+        requirements: []
+        specifications:
+          - spec-000011
+          - spec-000015
+    syncedAt: 2026-02-20T13:40:59.325Z
+    status: closed
   - githubIssue: 411
     type: improvement
     severity: low
     linkedTo:
-      requirements: []
+      requirements:
+        - req-000005
       createdRequirements: []
       specifications: []
       createdSpecifications: []
-    syncedAt: 2026-02-20T12:58:04.132Z
-    status: open
+      resolved:
+        requirements:
+          - req-000005
+        specifications: []
+    syncedAt: 2026-02-20T13:40:59.325Z
+    status: closed

--- a/.reqord/requirements/req-000005.yaml
+++ b/.reqord/requirements/req-000005.yaml
@@ -1,10 +1,10 @@
 id: req-000005
-version: '4.0'
+version: '5.0'
 title: Requirement/Specificationバージョン管理
 status: implemented
 priority: medium
 createdAt: 2026-02-07T10:00:00Z
-updatedAt: 2026-02-16T03:23:29.162Z
+updatedAt: 2026-02-20T14:13:19.911Z
 versionHistory:
   - version: 1.0.0
     status: implemented
@@ -28,6 +28,11 @@ versionHistory:
     summary: >-
       Major design change: Add reqord version command, fully separate versioning from status transitions. Removes
       --major/--patch from draft command. Backward incompatible with v3.0 (Issue #263)
+  - version: '5.0'
+    status: implemented
+    gitCommit: 273b8b8
+    changedAt: 2026-02-20T14:13:19.911Z
+    summary: 'Remove gitCommit field from versionHistory (feedback #411)'
 files:
   description: requirements/req-000005/description.md
   supplementary: []
@@ -39,7 +44,7 @@ successCriteria:
   - X.Y形式のバージョン番号をサポートする（1.0, 2.0, 1.1など）
   - versionHistory にバージョン履歴が記録される
   - reqord req history <id> / reqord spec history <id> でバージョン履歴を表示できる
-  - Gitコミットとバージョンが紐付けられる
+  - versionHistoryにgitCommitフィールドを持たない（git log -Sで導出する）
 format:
   type: ears
   ears:

--- a/.reqord/requirements/req-000005/description.md
+++ b/.reqord/requirements/req-000005/description.md
@@ -84,7 +84,8 @@ reqord version spec-000001 --patch --summary "Fix typo in design document"
 ### reqord req history \<id\> / reqord spec history \<id\>
 
 - バージョン履歴をタイムライン表示
-- 各バージョンのステータス、承認者、Gitコミットを表示
+- 各バージョンのステータス、承認者を表示
+- Gitコミットハッシュは `git log -S` で必要時に導出（YAMLには保存しない）
 
 ### バージョニングのタイミング
 
@@ -101,8 +102,8 @@ reqord version spec-000001 --patch --summary "Fix typo in design document"
 
 ## 技術的制約
 
-- Gitコミットハッシュとの紐付けはGit操作と連携
 - `versionHistory` 配列は追記のみ（履歴改変不可）
+- `versionHistory` にはgitCommitフィールドを持たない（`git log -S` で高速に導出可能なため、YAMLに重複して保持しない）
 
 ## コマンドインターフェースの移行計画（v4.0）
 
@@ -155,6 +156,7 @@ v4.0では、以下のコマンドオプションが廃止されます:
 | #209 | draft化時のバージョン指定（--major/--minor/--patch）を明記。Specificationも対象に拡大 |
 | #247 | セマンティックバージョニングから整数+小数点形式（X.Y）に簡素化（v3.0） |
 | #263 | reqord versionコマンドを追加し、バージョニングとステータス遷移を完全分離（v4.0、後方互換性なし） |
+| #411 | versionHistoryからgitCommitフィールドを削除。git log -Sで導出する方針に変更（v5.0） |
 
 ## 既存データの移行
 

--- a/.reqord/specifications/spec-000011.yaml
+++ b/.reqord/specifications/spec-000011.yaml
@@ -1,11 +1,11 @@
 id: spec-000011
 requirementId: req-000011
-title: 'Requirement承認フロー (GitHub PR連携)'
+title: Requirement承認フロー (GitHub PR連携)
 requirementVersion: '5.0'
-version: '1.0'
+version: '2.0'
 status: implemented
 createdAt: 2026-02-08T14:08:07.471Z
-updatedAt: 2026-02-15T14:50:00.000Z
+updatedAt: 2026-02-20T14:13:22.338Z
 versionHistory:
   - version: '1.0'
     status: draft
@@ -22,6 +22,11 @@ versionHistory:
     gitCommit: 32427ff
     changedAt: 2026-02-15T14:50:00.000Z
     summary: 'status: approved → implemented (PR #286)'
+  - version: '2.0'
+    status: implemented
+    gitCommit: 273b8b8
+    changedAt: 2026-02-20T14:13:22.338Z
+    summary: 'Fix unnecessary CLI command instruction in approval PR body (feedback #410)'
 files:
   design: specifications/spec-000011/design.md
   supplementary: []

--- a/.reqord/specifications/spec-000011/design.md
+++ b/.reqord/specifications/spec-000011/design.md
@@ -157,7 +157,7 @@ currentApproval: z.object({
 ### 変更内容
 status: draft → approved
 
-> このPRをマージすると、要件のステータスが `approved` に更新されます。
+> このPRをマージすると、要件のステータスが `approved` に確定します。
 ```
 
 ## 4. データフロー
@@ -186,12 +186,9 @@ status: draft → approved
 
 ### PRマージ後のステータス更新
 
-PRマージ後のステータス更新は、以下のいずれかの方法で実行する:
+PRマージ後の手動ステータス更新は不要。`reqord req approve` コマンドがブランチ上でstatusを `approved` に変更済みのため、PRマージによりmainブランチに反映されるだけで完了する。
 
-1. **手動更新（Phase 1）:** `reqord req update <id> --status approved`
-2. **GitHub Actions連携（Phase 2）:** PRマージイベントをトリガーにワークフローで自動更新
-
-Phase 1では手動更新を前提とし、Phase 2でGitHub Actionsによる自動化を追加する。
+> PR本文に手動更新の指示（`reqord req update` 等）を含めないこと。
 
 ## 5. テスト方針
 
@@ -220,10 +217,10 @@ Phase 1では手動更新を前提とし、Phase 2でGitHub Actionsによる自�
 **決定:** git/gh CLIの操作をリポジトリ層に隔離し、child_process.execFileで実行
 **理由:** テスト時のモック化が容易。また、将来的にOctokit.jsへの移行が必要になった場合も、リポジトリ層の差し替えのみで対応可能。
 
-### PRマージ後の手動更新（Phase 1）
+### PRマージ後の手動更新が不要な理由
 
-**決定:** Phase 1ではPRマージ後のステータス更新を手動で行い、GitHub Actions連携はPhase 2で対応
-**理由:** GitHub Actionsワークフローの設計・テストには追加の複雑さがある。まずCLI単体で完結するフローを確立し、自動化は段階的に導入する。
+**決定:** PRマージ後の手動ステータス更新は不要
+**理由:** `reqord req approve` コマンドがブランチ上でstatus を `approved` に変更しコミットする。PRマージでこの変更がmainに反映されるため、追加のステータス更新アクションは不要。旧設計の `pending_approval` ステータスは廃止済み。
 
 ### gh CLI依存
 

--- a/.reqord/specifications/spec-000015.yaml
+++ b/.reqord/specifications/spec-000015.yaml
@@ -1,11 +1,11 @@
 id: spec-000015
 requirementId: req-000015
-title: 'Specification承認フロー'
+title: Specification承認フロー
 requirementVersion: '5.0'
-version: '1.0'
+version: '2.0'
 status: implemented
 createdAt: 2026-02-08T14:08:07.812Z
-updatedAt: 2026-02-16T00:47:21.434Z
+updatedAt: 2026-02-20T14:13:24.845Z
 versionHistory:
   - version: '1.0'
     status: draft
@@ -22,6 +22,11 @@ versionHistory:
     gitCommit: d8c5de6
     changedAt: 2026-02-16T00:22:54.325Z
     summary: 'status: approved → implemented'
+  - version: '2.0'
+    status: implemented
+    gitCommit: 273b8b8
+    changedAt: 2026-02-20T14:13:24.845Z
+    summary: 'Fix unnecessary CLI command instruction in approval PR body (feedback #410)'
 files:
   design: specifications/spec-000015/design.md
   supplementary: []

--- a/.reqord/specifications/spec-000015/design.md
+++ b/.reqord/specifications/spec-000015/design.md
@@ -145,7 +145,7 @@ status: draft → approved
 ### 設計ファイル
 - `specifications/{specId}/design.md`
 
-> このPRをマージすると、仕様のステータスが `approved` に更新されます。
+> このPRをマージすると、仕様のステータスが `approved` に確定します。
 ```
 
 **designSummary抽出:** design.mdの「設計概要」セクション（## 1. 設計概要 の直下テキスト）を自動抽出してPR本文に含める。


### PR DESCRIPTION
## Summary

- Feedback #410 (spec-mismatch): 承認PR bodyの不要なCLIコマンド指示 → spec-000011, spec-000015にリンク・クローズ・flag解消
- Feedback #411 (improvement): versionHistoryからgitCommit削除提案 → req-000005にリンク・クローズ・flag解消
- req-000005 v5.0: gitCommit関連の記述をdescription.md・success criteriaから更新
- spec-000011 v2.0: PRマージ後の手動更新不要を明記（pending_approval廃止済み）
- spec-000015 v2.0: PRテンプレートの説明を修正

## Test plan

- [ ] `reqord feedback show 410 --json` でlinkedTo.resolvedにspec-000011, spec-000015が含まれる
- [ ] `reqord feedback show 411 --json` でlinkedTo.resolvedにreq-000005が含まれる
- [ ] req-000005のsuccess criteriaにgitCommit保持の記述がないこと
- [ ] spec-000011 design.mdにPRマージ後の手動更新指示がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)