### PR TITLE
fix(cli): allow spec approve when related requirement is implemented

### DIFF
--- a/.reqord/specifications/spec-000015/design.md
+++ b/.reqord/specifications/spec-000015/design.md
@@ -48,7 +48,7 @@ reqord spec approve <id> [--dry-run]
 Specification承認の前提条件は、Requirement承認より厳格:
 
 1. **Specificationのステータスがdraft**であること
-2. **関連Requirementのステータスがapprovedまたはapproved**であること
+2. **関連Requirementのステータスがapprovedまたはimplemented**であること
    - 未承認の要件に対する仕様承認は整合性に問題がある
 3. **design.mdが空でない（テンプレートのままではない）**こと
    - 設計文書が実際に記述されている必要がある
@@ -68,7 +68,7 @@ async function checkSpecApprovalPrerequisites(
 
   // 2. 関連Requirementのステータスチェック
   const req = await reqRepo.findById(cwd, spec.requirementId);
-  if (req && req.status !== "approved" && req.status !== "approved") {
+  if (req && req.status !== "approved" && req.status !== "implemented") {
     errors.push(`関連要件 ${spec.requirementId} が未承認です（現在: ${req.status}）`);
   }
 
@@ -192,7 +192,7 @@ status: draft → approved
 - **前提条件チェック（approve）**:
   - Specificationがdraftのときに成功すること
   - Specificationがdraft以外のときにエラーメッセージが返ること
-  - 関連Requirementがapproved/approvedのときに成功すること
+  - 関連Requirementがapproved/implementedのときに成功すること
   - 関連Requirementがdraftのときにエラーメッセージが返ること
   - design.mdがテンプレートのままのときにエラーメッセージが返ること
 - **ApprovalTarget構築**: type="specification"、files配列にdesign.mdが含まれること
@@ -227,8 +227,8 @@ status: draft → approved
 
 ### Requirement承認の前提条件化
 
-**決定:** Specification承認時に関連Requirementのapproved/approvedステータスを前提条件とする
-**理由:** 未承認の要件に対して仕様を承認しても、要件自体が変更される可能性がある。要件→仕様の承認順序を強制することで、手戻りリスクを最小化する。approvedも許容するのは、要件承認と仕様承認を並行して進められるようにするため。
+**決定:** Specification承認時に関連Requirementのapproved/implementedステータスを前提条件とする
+**理由:** 未承認の要件に対して仕様を承認しても、要件自体が変更される可能性がある。要件→仕様の承認順序を強制することで、手戻りリスクを最小化する。implementedも許容するのは、approvedの後の状態であり、仕様の再承認時にも対応するため。
 
 ### design.mdの空チェック
 

--- a/packages/cli/src/services/specification-service.test.ts
+++ b/packages/cli/src/services/specification-service.test.ts
@@ -354,6 +354,18 @@ describe("checkSpecApprovalPrerequisites", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("関連Requirementがimplementedの場合は成功", async () => {
+    const spec = makeSpecification({ status: "draft" });
+    const req = makeRequirement({ status: "implemented" });
+    mockSpecRepo.findByIdOrThrow.mockResolvedValue(spec);
+    mockReqRepo.findById.mockResolvedValue(req);
+    mockSpecRepo.loadFile.mockResolvedValue("# Design");
+
+    const result = await checkSpecApprovalPrerequisites("/cwd", "spec-000001");
+
+    expect(result.ok).toBe(true);
+  });
+
   it("関連Requirementがdraftの場合はエラー", async () => {
     const spec = makeSpecification({ status: "draft" });
     const req = makeRequirement({ status: "draft" });

--- a/packages/cli/src/services/specification-service.ts
+++ b/packages/cli/src/services/specification-service.ts
@@ -162,7 +162,7 @@ export async function checkSpecApprovalPrerequisites(
   const req = await reqRepo.findById(cwd, spec.requirementId);
   if (!req) {
     errors.push(`Related requirement ${spec.requirementId} not found`);
-  } else if (req.status !== "approved") {
+  } else if (req.status !== "approved" && req.status !== "implemented") {
     errors.push(`Related requirement ${spec.requirementId} is not approved (current: ${req.status})`);
   }
 


### PR DESCRIPTION
## Summary

- `reqord spec approve` の前提条件チェックで、関連requirementのstatusが `implemented` の場合も許可するように修正
- `implemented` は `approved` の後の状態であり、仕様承認の前提条件として妥当

## Test plan

- [x] 関連Requirementが `implemented` の場合に成功するテストを追加
- [x] 既存テスト全件パス (1138 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)