### PR TITLE
chore(reqord): resolve feedback #410 flags on spec-000011, spec-000015

### DIFF
--- a/.reqord/specifications/spec-000011.yaml
+++ b/.reqord/specifications/spec-000011.yaml
@@ -30,13 +30,7 @@ versionHistory:
 files:
   design: specifications/spec-000011/design.md
   supplementary: []
-flags:
-  - type: feedback-review
-    reason: 'Feedback from issue #410'
-    createdAt: 2026-02-20T13:52:38.053Z
-    relatedIssues:
-      - 410
-    severity: low
+flags: []
 currentApproval:
   version: '2.0'
   phase: specification

--- a/.reqord/specifications/spec-000015.yaml
+++ b/.reqord/specifications/spec-000015.yaml
@@ -30,13 +30,7 @@ versionHistory:
 files:
   design: specifications/spec-000015/design.md
   supplementary: []
-flags:
-  - type: feedback-review
-    reason: 'Feedback from issue #410'
-    createdAt: 2026-02-20T13:52:25.475Z
-    relatedIssues:
-      - 410
-    severity: low
+flags: []
 currentApproval:
   version: '2.0'
   phase: specification


### PR DESCRIPTION
## Summary

- spec-000011, spec-000015 の feedback-review フラグ (#410) を解消
- ドキュメント修正は PR #418 で対応済み、承認は PR #421, #422 で完了済み

## Test plan

- [x] `reqord spec show spec-000011 --json` で flags が空
- [x] `reqord spec show spec-000015 --json` で flags が空

🤖 Generated with [Claude Code](https://claude.com/claude-code)