### PR TITLE
fix: spec-000012 design.md レビュー指摘修正

### DIFF
--- a/.reqord/specifications/spec-000012/design.md
+++ b/.reqord/specifications/spec-000012/design.md
@@ -176,7 +176,7 @@ function traverseDependencyGraph(
 
   while (queue.length > 0) {
     const { id, depth, path, relation } = queue.shift()!;
-    if (visited.has(id)) continue;
+    if (visited.has(id)) continue;  // ダイヤモンド依存: 同一ノードへの複数経路のうち最初到達のみ記録
     if (maxDepth && depth > maxDepth) continue;
     visited.add(id);
 
@@ -311,7 +311,7 @@ export async function createPrComment(
   → notifyCommand.action("req-000011", { message: "優先度変更" })
     → impactService.analyzeImpact(cwd, "req-000011") → 影響先取得
     → 関連IssueのステータスをGitHub APIで確認（openのみ通知対象）
-    → 各影響先に対して（バッチ処理: 100件/時以下）:
+    → 各影響先に対して（バッチ処理: 100件/時以下、1件毎に36秒のスリープ間隔）:
       → 通知コメント生成
       → githubRepo.createIssueComment(issueNumber, comment) or
         githubRepo.createPrComment(prNumber, comment)


### PR DESCRIPTION
## Summary
- PR #465 のClaude reviewで指摘された spec-000012 design.md の明確化を実施

## Changes
- ダイヤモンド依存: BFS visitedチェックに「同一ノードへの複数経路のうち最初到達のみ記録」のコメント追加
- 通知バッチ処理: 「100件/時以下」に具体的なスリープ間隔（36秒/件）を明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)